### PR TITLE
fix: remove redundant code in memcell extraction

### DIFF
--- a/evaluation/src/adapters/evermemos/stage1_memcells_extraction.py
+++ b/evaluation/src/adapters/evermemos/stage1_memcells_extraction.py
@@ -527,27 +527,8 @@ async def process_single_conversation(
                 memcell_dict, cluster_state
             )
 
-        # Save cluster state
+        # Save cluster state (cluster_storage.save_cluster_state internally saves both cluster_state and cluster_map)
         await cluster_storage.save_cluster_state(group_id, cluster_state.to_dict())
-
-        # Export clustering results
-        cluster_output_dir = Path(save_dir) / "clusters" / f"conv_{conv_id}"
-        cluster_output_dir.mkdir(parents=True, exist_ok=True)
-
-        state_file = cluster_output_dir / f"cluster_state_{group_id}.json"
-        with open(state_file, "w", encoding="utf-8") as f:
-            json.dump(
-                cluster_state.to_dict(), f, ensure_ascii=False, indent=2, default=str
-            )
-
-        assignments_file = cluster_output_dir / f"cluster_map_{group_id}.json"
-        with open(assignments_file, "w", encoding="utf-8") as f:
-            json.dump(
-                {"assignments": cluster_state.eventid_to_cluster},
-                f,
-                ensure_ascii=False,
-                indent=2,
-            )
 
         cluster_stats = cluster_mgr.get_stats()
 

--- a/src/memory_layer/memcell_extractor/conv_memcell_extractor.py
+++ b/src/memory_layer/memcell_extractor/conv_memcell_extractor.py
@@ -511,9 +511,6 @@ class ConvMemCellExtractor(MemCellExtractor):
             summary_text = boundary_detection_result.topic_summary or (
                 fallback_text.strip()[:200] if fallback_text else "Conversation segment"
             )
-            summary_text = boundary_detection_result.topic_summary or (
-                fallback_text.strip()[:200] if fallback_text else "Conversation segment"
-            )
 
             # Create basic MemCell (without episode, foresight, event_log, embedding)
             memcell = MemCell(


### PR DESCRIPTION
  ## Summary
  This PR fixes two redundant code issues in the memcell extraction pipeline:

  1. **Duplicate summary_text assignment in conv_memcell_extractor.py**
     - Removed the duplicate `summary_text` assignment on lines 514-516
     - This code was already computed earlier in the boundary detection logic

  2. **Redundant cluster state file exports in stage1_memcells_extraction.py**
     - Removed redundant manual file exports for cluster state and cluster map on lines 533-550
     - The `cluster_storage.save_cluster_state()` method already handles saving both `cluster_state` and `cluster_map` internally
     - These manual exports were duplicating the work already done by `InMemoryClusterStorage`

  ## Changes Made

  ### Modified Files:
  - `src/memory_layer/memcell_extractor/conv_memcell_extractor.py`: Removed duplicate summary_text assignment
  - `evaluation/src/adapters/evermemos/stage1_memcells_extraction.py`: Removed redundant cluster state file exports

  ### Impact:
  - Cleaner, more maintainable code
  - Removes redundant I/O operations for cluster state exports
  - No functional changes - these were purely cosmetic/cleanup changes

  ## Testing
  - [x] Code changes are minimal and safe
  - [ ] Memcell extraction functionality remains unchanged
  - [ ] Cluster state persistence still works correctly (via InMemoryClusterStorage)
  - [ ] Run existing test suite to verify no regressions

  ## Notes
  These changes improve code quality by removing unnecessary duplication and leveraging existing storage abstractions. The `cluster_storage.save_cluster_state()` method is designed to save all necessary cluster-related files, making manual exports redundant.