### PR TITLE
fix: remove unused MongoDB init mount and hardcoded paths

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "last_updated": "2025-01-03",
 
   "paths": {
-    "root": "/Users/admin/Desktop/episodic_memory/memsys",
+    "root": ".",
 
     "data": {
       "description": "Raw data storage paths",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,6 @@ services:
       - "27017:27017"
     volumes:
       - mongodb_data:/data/db
-      - ./docker/mongodb/init:/docker-entrypoint-initdb.d
     networks:
       - memsys-network
     healthcheck:


### PR DESCRIPTION
## Summary

Fix two simple issues:

## Changes

1. **Remove unused MongoDB init volume mount** - The `./docker/mongodb/init` directory doesn't exist in the repository. MongoDB initialization is handled at the application layer (Beanie ODM + migration manager), not via Docker init scripts.

2. **Remove hardcoded local paths** - Changed `config.json` root from hardcoded `/Users/admin/Desktop/episodic_memory/memsys` to `.` for portability.

## Testing

Verified changes locally.

Fixes EverMind-AI/EverMemOS#90