### PR TITLE
fix: unify game-of-throne-demo EVERMEMOS_URL default port to 1995

### DIFF
--- a/use-cases/game-of-throne-demo/backend/src/server.ts
+++ b/use-cases/game-of-throne-demo/backend/src/server.ts
@@ -13,7 +13,7 @@ const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'openai/gpt-5.2';
 const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
 const USE_EVERMEMOS = process.env.USE_EVERMEMOS === 'true';
-const EVERMEMOS_URL = process.env.EVERMEMOS_URL || 'http://localhost:8001';
+const EVERMEMOS_URL = process.env.EVERMEMOS_URL || 'http://localhost:1995';
 const EVERMEMOS_API_KEY = process.env.EVERMEMOS_API_KEY || '';
 const EVERMEMOS_GROUP_ID = process.env.EVERMEMOS_GROUP_ID || 'asoiaf';
 


### PR DESCRIPTION
saw issue #28 was still open. the game-of-throne-demo server.ts had port 8001 as default but EverMemOS server actually runs on 1995. PR #181 fixed ports for the EverMemOS demos but game-of-throne-demo was added in #186 after and got missed.

tested:
- typescript compiles clean
- no other 8001 references left in the codebase
- data flow checked end-to-end

cloud mode uses env override so only local dev affected. fixes #28

happy to adjust if needed, thanks.