### PR TITLE
feat(routine): scaffold auto-bench weekly routine

### DIFF
--- a/.auto_bench/seen_systems.json
+++ b/.auto_bench/seen_systems.json
@@ -1,0 +1,82 @@
+{
+  "$schema_version": "1.0",
+  "$schema_doc": "Each entry tracks one memory framework the auto-bench routine has considered. Status values: 'integrated' (adapter merged), 'candidate' (adapter being developed), 'rejected' (does not meet decision rules), 'failed' (adapter exists but smoke test failed), 'needs-revisit' (re-evaluate when upstream changes). Tier values: 'local-with-cloud-llm' (memory backend local, LLM API cloud — ACCEPTED), 'local-with-local-llm' (everything local incl. inference — REWRITE config to OpenRouter), 'saas-only' (memory operations require vendor SaaS — REJECTED).",
+  "$decision_rules_version": "2026-04-21",
+  "$decision_rules": {
+    "accept": "Memory store / search operations run in a local process or local container. LLM and embedding calls may go to cloud APIs (OpenRouter / OpenAI / etc.).",
+    "rewrite": "If the system defaults to local LLM / embedding inference, force-rewrite its config to use OpenRouter via LLM_BASE_URL + LLM_API_KEY before benchmarking.",
+    "reject": "Any system whose memory operations require calling a vendor-hosted endpoint (e.g. *.mem0.ai, api.getzep.com cloud-only mode) is rejected, even if a self-hosted version is theoretically possible but not packaged."
+  },
+  "last_updated": "2026-04-21",
+  "systems": [
+    {
+      "name": "evermemos",
+      "display_name": "EverMemOS",
+      "github": "EverMind-AI/EverMemOS",
+      "first_seen": "2025-11-26",
+      "status": "integrated",
+      "tier": "local-with-cloud-llm",
+      "memory_backend": "local",
+      "adapter_path": "evaluation/src/adapters/evermemos_adapter.py",
+      "config_path": "evaluation/config/systems/evermemos.yaml",
+      "infra_required": ["mongodb", "elasticsearch", "milvus", "redis"],
+      "estimated_ram_gb": 12,
+      "notes": "Native system. Fork target. Routine should never modify this adapter."
+    },
+    {
+      "name": "mem0",
+      "display_name": "Mem0 (upstream evaluation = SaaS)",
+      "github": "mem0ai/mem0",
+      "first_seen": "2025-11-26",
+      "status": "rejected",
+      "tier": "saas-only",
+      "memory_backend": "saas",
+      "rejection_reason": "EverOS upstream evaluates Mem0 via MemoryClient (cloud), which violates 'local memory backend' rule. The mem0 Python package does expose a local Memory() class — reconsider as 'needs-revisit' if a local-mode adapter is contributed.",
+      "notes": "If you decide to add a local-mode adapter, change status to 'candidate' and remove from routine deny-list."
+    },
+    {
+      "name": "memos",
+      "display_name": "MemOS (upstream evaluation = SaaS)",
+      "github": null,
+      "first_seen": "2025-11-26",
+      "status": "rejected",
+      "tier": "saas-only",
+      "memory_backend": "saas",
+      "rejection_reason": "Upstream evaluation uses MEMOS_KEY against vendor API. Same revisit logic as Mem0."
+    },
+    {
+      "name": "memu",
+      "display_name": "MemU (upstream evaluation = SaaS)",
+      "github": null,
+      "first_seen": "2025-11-26",
+      "status": "rejected",
+      "tier": "saas-only",
+      "memory_backend": "saas",
+      "rejection_reason": "Upstream evaluation uses MEMU_API_KEY against vendor API."
+    },
+    {
+      "name": "zep",
+      "display_name": "Zep",
+      "github": "getzep/zep",
+      "first_seen": "2025-11-26",
+      "status": "rejected",
+      "tier": "saas-only",
+      "memory_backend": "saas",
+      "rejection_reason": "Community Edition deprecated; only Graphiti engine remains open source. No clean self-hosted memory path that matches upstream evaluation conditions."
+    }
+  ],
+  "deny_keywords": [
+    "managed memory service",
+    "fully managed",
+    "cloud-only",
+    "API-only access",
+    "no self-hosted option"
+  ],
+  "must_have_keywords": [
+    "self-hosted",
+    "docker compose",
+    "open source",
+    "local deployment",
+    "pip install"
+  ]
+}

--- a/.claude/ROUTINE_PROMPT.md
+++ b/.claude/ROUTINE_PROMPT.md
@@ -1,0 +1,76 @@
+# Routine main prompt — Auto-Bench for DuffyCoder/EverOS
+
+> Paste the block below into the "Prompt" field when creating the routine at
+> https://claude.ai/code/routines. Detail lives in the three skills
+> (`discover-memory-frameworks`, `write-eval-adapter`,
+> `run-bench-with-docker-stack`) and in `CLAUDE.md` — keep this prompt short.
+
+---
+
+## Prompt (paste into routine)
+
+You are the auto-bench routine for DuffyCoder/EverOS. Follow the rules in
+`CLAUDE.md § Auto-Bench Routine Rules`. All detailed steps live in skills — do
+not re-derive the work.
+
+Run, in order:
+
+1. **Discover.** Invoke the `discover-memory-frameworks` skill. It returns a
+   JSON list of candidates. If `candidates` is empty, exit immediately — no
+   PR, no email.
+
+2. **For each candidate in the list** (sequentially, not in parallel — skills
+   touch `registry.py`):
+   a. Checkout a fresh branch: `claude/auto-bench-<name>-$(date +%Y%m%d)`.
+   b. Invoke the `write-eval-adapter` skill with the candidate's record.
+   c. Invoke the `run-bench-with-docker-stack` skill. It produces
+      `evaluation/results/<run-name>/eval_results.json` and updates
+      `.auto_bench/seen_systems.json`.
+   d. Commit: adapter file, config file, registry edit, `seen_systems.json`.
+      Commit message: `[Auto-Bench] Add <name> adapter — LoCoMo <pass|fail>`.
+      Push branch.
+   e. Open DRAFT PR per `CLAUDE.md § Branching and PR conventions`. Title
+      `[Auto-Bench] Evaluate <name> on LoCoMo` plus any failure tag. Body
+      template is in the addendum — fill from `eval_results.json` only.
+   f. Teardown already happened inside the run-bench skill. Verify no
+      `auto-bench-<name>-*` containers remain before moving on.
+
+3. **Notify.** After all candidates are processed, send ONE Gmail via the
+   Gmail connector:
+     - To: the routine owner's configured email.
+     - Subject: `Auto-Bench weekly: <N_pass>/<N_total> candidates passed`.
+     - Body: one bullet per candidate with PR URL and headline metric.
+
+## Non-negotiables (abort if violated)
+
+- Only benchmark systems with a local memory backend (Rule 1 in the skill).
+- LLM/embedding config MUST be rewritten to `${LLM_API_KEY}` /
+  `${LLM_BASE_URL}` (OpenRouter) before smoke (Rule 2).
+- If `estimated_ram_gb > 14` after stopping EverOS stack, run LoCoMo in
+  batches via `--from-conv`/`--to-conv` (Rule 3).
+- Do NOT add dependencies. If a candidate needs a missing pip package, open
+  the PR with `[install-failed]` tag and no eval results.
+- Do NOT modify anything outside `evaluation/src/adapters/`,
+  `evaluation/config/systems/`, `evaluation/results/`, `.auto_bench/`.
+- Never invent benchmark numbers. Only quote what you read from
+  `eval_results.json`.
+
+## First-run dry-run instruction
+
+For the FIRST routine run (this paragraph should be deleted once validated):
+**DRY RUN — run discover + write-adapter steps, but skip `run-bench` and skip
+PR creation. Instead, print the adapter file diff and the system YAML to the
+session log. Send no email.**
+
+## Failure behavior
+
+If any step throws, record the failure in `.auto_bench/seen_systems.json`
+against that candidate (`status: failed`, `last_error: <first 20 lines>`),
+continue to the next candidate, and include the failure in the Gmail summary.
+Do not abort the whole routine on one candidate's failure.
+
+## Session context for humans
+
+The Gmail body and the PR footer both include
+`session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}` so humans
+can replay the run.

--- a/.claude/rules/auto-bench-routine.md
+++ b/.claude/rules/auto-bench-routine.md
@@ -1,0 +1,69 @@
+## Auto-Bench Routine Rules
+
+These rules apply ONLY when this session was started by the auto-bench routine. You will know because the routine prompt explicitly says so. In normal interactive sessions, ignore this section.
+
+### Three decision rules (non-negotiable)
+
+1. **Local memory backend only.** Only benchmark systems whose memory store/search runs in a local process or local container. Reject systems whose memory operations require a vendor SaaS endpoint.
+2. **Force LLM/embedding to OpenRouter.** When integrating a candidate, rewrite its LLM and embedding config to use `LLM_BASE_URL` and `LLM_API_KEY` (which are set to OpenRouter). Never benchmark a system using its default local inference model unless that model is < 1 B parameters.
+3. **Batch by RAM budget.** The cloud environment has 16 GB RAM. EverOS infra alone uses ~10 GB. If estimated total > 14 GB, run the candidate in batched chunks (split LoCoMo questions into N groups, restart docker stack between groups).
+
+### File-level scope
+
+Auto-bench routine sessions may modify ONLY:
+- `evaluation/src/adapters/` — new adapter files only, never modify existing ones
+- `evaluation/config/systems/` — new system configs only
+- `evaluation/results/` — generated results
+- `.auto_bench/` — internal state (seen_systems.json, scan logs)
+
+Auto-bench routine sessions MUST NOT modify:
+- Anything in `src/` (the EverOS core)
+- Existing adapters or system configs
+- `pyproject.toml` / `uv.lock` (no dependency changes from the routine)
+- `CLAUDE.md` itself
+
+If the routine needs a dependency that is not already in `pyproject.toml [project.optional-dependencies] evaluation-full`, abort the candidate and note this in the PR description. Do not silently add dependencies.
+
+### Branching and PR conventions
+
+- All routine branches MUST start with `claude/auto-bench-`. Format: `claude/auto-bench-<system-name>-YYYYMMDD`.
+- Open all PRs as **draft**.
+- PR title format: `[Auto-Bench] Evaluate <system-name> on <dataset>`.
+- PR body MUST include, in this order:
+  1. One-paragraph summary of what the system does (paraphrase from its README).
+  2. Tier classification and which decision rule path was taken.
+  3. Smoke test result (pass / fail / chunk-pass).
+  4. Full benchmark result table comparing to top-3 already-integrated systems from `seen_systems.json`.
+  5. Adapter implementation notes — anything non-obvious about how the system's interface was mapped.
+  6. Footer: `Created by automated routine — session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}`
+
+### Workflow contract
+
+For each candidate that passes discovery:
+
+1. Clone the candidate repo into `/tmp/candidate/<name>/` (NOT into the EverOS repo working tree).
+2. Read its README, identify the SDK entry point and config surface.
+3. If candidate ships its own `docker-compose.yaml`, start it with a unique project name to avoid colliding with EverOS infra: `docker compose -p auto-bench-<name> up -d`.
+4. Write the adapter at `evaluation/src/adapters/<name>_adapter.py` using `evermemos_adapter.py` as the structural reference (NOT mem0_adapter.py — that one targets a SaaS API and is the wrong template for our rules).
+5. Write the system config at `evaluation/config/systems/<name>.yaml`. The LLM/embedding section MUST point at `${LLM_BASE_URL}` and `${LLM_API_KEY}` even if the candidate normally uses its own.
+6. Run smoke first: `uv run python -m evaluation.cli --dataset locomo --system <name> --smoke`.
+7. If smoke passes AND total RAM estimate ≤ 14 GB: run full LoCoMo. Skip LongMemEval unless explicitly requested — it is too token-heavy for weekly automation.
+8. If smoke passes but RAM > 14 GB: run in batches (see Rule 3). The current evaluation CLI may not support `--questions-range` natively — if so, write the batched results manually and merge in the report.
+9. After each candidate (pass or fail), tear down its docker stack: `docker compose -p auto-bench-<name> down -v`. THIS IS CRITICAL — without it, the next candidate will OOM.
+10. Update `.auto_bench/seen_systems.json` with the new entry and commit.
+
+### Failure modes and what to do
+
+| Failure | Action |
+|---|---|
+| Candidate has no Python SDK or REST API | Add to `seen_systems.json` with `status: rejected, rejection_reason: "no programmatic interface"`. Do not open PR. |
+| Candidate's `pip install` fails in the cloud env | Add to `seen_systems.json` with `status: failed, last_error: <traceback first 20 lines>`. Open PR with `[install-failed]` tag for visibility, no eval results. |
+| Smoke test crashes | Open PR titled `[Auto-Bench][smoke-failed] ...` with the traceback in the body. Do not run full eval. |
+| OOM during full run | Switch to batch mode. If batch mode also OOMs, abort and open PR with `[oom-batched]` tag. |
+| Timeout (> 90 min total per candidate) | Abort that candidate, continue with the next one. |
+
+### Memory and reasoning hygiene
+
+- Do NOT speculate about benchmark numbers. Only report numbers actually emitted by `evaluation/results/<run>/eval_results.json`.
+- When comparing to existing systems' historical scores, read them from `seen_systems.json` or `evaluation/results/`. Never quote a number from training data or from a paper.
+- When summarizing a candidate's README in the PR, paraphrase. Do not copy more than ~15 words verbatim.

--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Claude Code Routine setup script — auto-bench routine.
+#
+# Runs ONCE per routine session on the cloud container (output cached ~7 days).
+# Keep cheap and idempotent.
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+echo "::group::Python dependencies (evaluation-full)"
+uv sync --group evaluation-full
+echo "::endgroup::"
+
+echo "::group::Preload EverMemOS docker images"
+# EverMemOS infra is NOT started by the routine (candidates don't need it),
+# but pulling keeps the cached image layer available for future cold runs.
+docker compose -f docker-compose.yaml pull --quiet || \
+  echo "  (pull failed — skipping; routine doesn't require EverOS infra)"
+echo "::endgroup::"
+
+echo "::group::Candidate scratch dir"
+mkdir -p /tmp/candidate
+echo "::endgroup::"
+
+echo "::group::Environment sanity"
+missing=()
+[[ -z "${LLM_API_KEY:-}" ]] && missing+=("LLM_API_KEY")
+[[ -n "${LLM_API_KEY:-}" ]] && \
+  [[ "${LLM_API_KEY}" != sk-or-v1-* ]] && \
+  echo "  ⚠️  LLM_API_KEY is set but not in OpenRouter format (sk-or-v1-...); fairness baseline assumes OpenRouter."
+export LLM_BASE_URL="${LLM_BASE_URL:-https://openrouter.ai/api/v1}"
+echo "  LLM_BASE_URL=${LLM_BASE_URL}"
+
+if (( ${#missing[@]} > 0 )); then
+  echo "  ❌ Missing required env vars: ${missing[*]}"
+  echo "     Set them at https://claude.ai/code/routines for this routine."
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "::group::LoCoMo dataset"
+if [[ ! -f evaluation/data/locomo/locomo10.json ]]; then
+  echo "  ❌ evaluation/data/locomo/locomo10.json missing"
+  echo "     The dataset is committed to the repo; this is unexpected on a clean clone."
+  exit 1
+fi
+echo "  ✅ locomo10.json present ($(wc -c < evaluation/data/locomo/locomo10.json) bytes)"
+echo "::endgroup::"
+
+echo "Setup complete."

--- a/.claude/skills/discover-memory-frameworks/SKILL.md
+++ b/.claude/skills/discover-memory-frameworks/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: discover-memory-frameworks
+description: Use this skill at the start of an auto-bench routine run to find newly released or newly trending memory frameworks for LLM agents that meet the local-deployment criteria. Triggers when the routine prompt asks to "find new memory systems", "scan for new frameworks", "check for memory framework releases", or any equivalent. The skill returns a JSON list of candidate systems that are NOT already in .auto_bench/seen_systems.json and that pass the three decision rules (local memory backend, configurable LLM/embedding, not SaaS-only).
+---
+
+# Discover Memory Frameworks
+
+This skill is the **first step** of every auto-bench routine run. Its job is to produce a clean, deduplicated, decision-rule-filtered list of new candidate memory frameworks. Downstream skills (write-eval-adapter, run-bench) operate on this list.
+
+## When to use
+
+Use this skill whenever the prompt asks to find new / recent / trending memory frameworks. Do NOT use it for evaluating already-known systems — those go straight to the bench-running skill.
+
+## Hard constraints (the three decision rules)
+
+These come from the user's explicit decisions and are non-negotiable. A candidate that violates any one of these is `rejected`, NOT `candidate`.
+
+**Rule 1 — Local memory backend**
+The system's memory store/search operations must run in a local Python process or local Docker container. Reject any system whose store/search calls require hitting a vendor SaaS endpoint (e.g. `*.mem0.ai`, `api.getzep.com` cloud mode, `api.evermind.ai` cloud mode).
+
+How to check: read the system's README and quickstart. Look for:
+- "self-hosted" / "open source" / `docker compose up` / `pip install <pkg>` and a local `Memory()` class → likely passes Rule 1
+- "Sign up for an API key" / "managed memory service" / cloud-only quickstart → likely fails Rule 1
+
+If in doubt, look at the actual code of the quickstart example. If the quickstart `import` line gives a class that takes a base URL pointing at the vendor's domain, it fails Rule 1.
+
+**Rule 2 — Configurable LLM and embedding**
+The system's LLM and embedding model choices must be reconfigurable. The benchmark will rewrite them to point at OpenRouter via `LLM_BASE_URL` and `LLM_API_KEY`.
+
+How to check: look for `config.json` / `settings.py` / `LLM_PROVIDER` env var / OpenAI-compatible client usage in the system code.
+
+If LLM/embedding is hard-coded to a local model with no override, mark `unconfigurable-local-inference` and reject.
+
+**Rule 3 — Reasonable infra footprint**
+The system's local infra must plausibly fit alongside EverMemOS in 16 GB RAM. Sum estimated infra:
+- EverOS baseline: 10 GB (MongoDB + Elasticsearch + Milvus + Redis)
+- Candidate's required services
+- Plus 2 GB safety margin
+
+If estimated total > 14 GB, mark `oversize-infra` but DO NOT reject — flag for batch processing instead. The bench skill will handle it via chunked execution.
+
+## Sources to scan (in priority order)
+
+1. **arXiv recent submissions**: `cs.CL` and `cs.AI` filtered to last 7 days, search terms "memory" / "long-term memory" / "memory system" / "agent memory". Use web_search.
+
+2. **GitHub trending**:
+   - https://github.com/topics/llm-memory
+   - https://github.com/topics/agent-memory
+   - https://github.com/topics/long-term-memory
+   - Filter by "updated in last 7 days" and "Python" language.
+
+3. **Reference survey**: arXiv:2512.13564v2 ("Memory in the Age of LLMs") — check if a new version has been posted and diff its system inventory against `seen_systems.json`.
+
+4. **Community signals** (lower priority, more noise):
+   - r/LocalLLaMA new posts mentioning memory frameworks
+   - HackerNews / Show HN tagged with memory/agent
+
+## Filter and dedupe
+
+For each raw candidate found:
+
+1. Normalize the name to lowercase, strip prefixes like "the".
+2. Check against `seen_systems.json` `systems[].name` and `systems[].display_name`. If matched, skip — but if matched entry has `status: "needs-revisit"`, include it.
+3. Apply Rules 1, 2, 3 above using the system's README.
+4. Estimate `tier` field:
+   - `local-with-cloud-llm` → preferred, no rewrite needed
+   - `local-with-local-llm` → acceptable, mark `requires_config_rewrite: true`
+   - `saas-only` → reject
+
+## Output format
+
+Return a JSON object on stdout (do not narrate around it):
+
+```json
+{
+  "scan_date": "2026-04-21",
+  "raw_candidates_found": 7,
+  "candidates": [
+    {
+      "name": "memoryos",
+      "display_name": "MemoryOS",
+      "github": "BAI-LAB/MemoryOS",
+      "tier": "local-with-cloud-llm",
+      "memory_backend": "local",
+      "infra_required": ["sqlite"],
+      "estimated_ram_gb": 1,
+      "requires_config_rewrite": false,
+      "discovered_via": "arXiv 2026-04-18, github trending",
+      "readme_url": "https://github.com/.../README.md",
+      "license": "Apache-2.0",
+      "first_release_or_update": "2026-04-15"
+    }
+  ],
+  "rejected": [
+    {
+      "name": "somecloudmem",
+      "rejection_reason": "saas-only — quickstart requires API key from vendor",
+      "rejection_rule": 1
+    }
+  ]
+}
+```
+
+If `candidates` is empty, the routine should exit gracefully without opening any PR or sending any email.
+
+## What NOT to do
+
+- Do NOT open the routine's PR from inside this skill. This skill only discovers and filters.
+- Do NOT clone any candidate repo from inside this skill. Cloning happens in the next skill (write-eval-adapter), and only for systems that pass all rules.
+- Do NOT trust GitHub star counts or "trending" position as a signal of quality. A 50-star research framework can be more interesting than a 5k-star wrapper.
+- Do NOT include MemorySparse Attention (MSA) or HyperMem — these are EverMind's own follow-up work and are tracked separately.
+- Do NOT run web searches with the year hardcoded (e.g. "memory framework 2025") — use "memory framework recent" or omit the year. The current year is whatever today's date is.

--- a/.claude/skills/run-bench-with-docker-stack/SKILL.md
+++ b/.claude/skills/run-bench-with-docker-stack/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: run-bench-with-docker-stack
+description: Use after write-eval-adapter has produced an adapter + config + registry entry for a candidate memory framework. This skill runs the LoCoMo benchmark against that one candidate, orchestrating the EverOS docker infra and the candidate's own docker stack (if any), handling 16 GB RAM budget via batch splits, and emitting a single merged report and updated seen_systems.json entry. Triggers when the routine prompt says "run bench for <system>", "benchmark <system>", or chains into this step after adapter is in place. Does NOT open the PR — that is the main prompt's job.
+---
+
+# Run Bench With Docker Stack
+
+This skill is the **third step** of every auto-bench routine run. It takes ONE candidate whose adapter is already written and registered, executes the LoCoMo evaluation inside the cloud container's 16 GB RAM budget, and leaves results ready for the routine's PR step.
+
+## When to use
+
+- After `write-eval-adapter` has written `evaluation/src/adapters/<name>_adapter.py`, `evaluation/config/systems/<name>.yaml`, and added the registry line.
+- Once per candidate. If the routine has 3 candidates, call this skill 3 times — with a full docker teardown between each.
+- Do NOT use this skill if the adapter file is missing or the config is missing — fail loudly instead.
+
+## Preconditions you MUST verify before starting
+
+Run each of these and abort with a clear message if any fails:
+
+```bash
+# 1. Adapter file exists
+test -f evaluation/src/adapters/<name>_adapter.py
+
+# 2. System config exists
+test -f evaluation/config/systems/<name>.yaml
+
+# 3. Registry has the new entry
+python -c "from evaluation.src.adapters.registry import list_adapters; assert '<name>' in list_adapters()"
+
+# 4. Required env vars are present
+: "${LLM_API_KEY:?LLM_API_KEY (OpenRouter key sk-or-v1-...) is required}"
+: "${LLM_BASE_URL:=https://openrouter.ai/api/v1}"
+
+# 5. LoCoMo data is present
+test -f evaluation/data/locomo10.json || {
+  echo "LoCoMo data missing — run the data-download script"
+  exit 1
+}
+```
+
+## RAM budget and batching algorithm
+
+**Budget facts (verified):**
+- Cloud container: 16 GB RAM total.
+- EverOS infra baseline (MongoDB + Elasticsearch + Milvus + Redis): ~10 GB when all services are running.
+- Safety margin: 2 GB (Python driver, docker daemon overhead, OS).
+- Usable budget for candidate: **4 GB** if EverOS stack must stay up, **14 GB** if the candidate does not need any of EverOS's services.
+
+**Decision tree for candidate start-up:**
+
+1. Read `estimated_ram_gb` for this candidate from `.auto_bench/seen_systems.json`. If missing, default to 3.
+2. Does the adapter import anything from `memory_layer.*` or `agentic_layer.*`? (External-call adapters should NOT — this should be NO.)
+   - If YES: the adapter is mis-classified; abort and escalate to human.
+   - If NO (expected): EverOS docker stack is NOT required for this candidate. Stop it before benchmarking:
+
+     ```bash
+     docker compose -f docker-compose.yaml down
+     ```
+
+     Now the full 14 GB is available for the candidate.
+
+3. If the candidate ships its own `docker-compose.yaml`, start it with a unique project name:
+
+   ```bash
+   cd /tmp/candidate/<name>/
+   docker compose -p auto-bench-<name> up -d
+   # Wait for health checks
+   docker compose -p auto-bench-<name> ps
+   ```
+
+   Project-name isolation prevents candidate services with generic names (`postgres`, `redis`, `chroma`, etc.) from colliding with EverOS's own stack IF you later decide to run both. For this routine we always stop EverOS first, so this is belt-and-suspenders.
+
+4. If `estimated_ram_gb > 12`, set `BATCH_SIZE=2` (5 batches × 2 convs each). Else if `> 6`, set `BATCH_SIZE=5` (2 batches × 5 convs). Else `BATCH_SIZE=10` (single run).
+
+## Output-path contract (READ FIRST — harness gotchas)
+
+These three facts come from `evaluation/cli.py` and `evaluation/src/core/pipeline.py` and dictate the whole batching design:
+
+1. **`--to-conv` is EXCLUSIVE.** `--from-conv 0 --to-conv 5` processes conversations 0..4 (five conversations). Source: `cli.py:107`, `pipeline.py:96,109,617`.
+2. **Default output dir = `results/{dataset}-{system}[-{run_name}]`.** Passing `--run-name foo` does NOT produce `results/foo/`. Source: `cli.py:211-223`. Always pass `--output-dir` explicitly so the same path is readable and isolatable.
+3. **Pipeline loads checkpoint from output_dir and skips completed stages.** Re-running the CLI with the same `--output-dir` after any stage is marked complete causes that stage to be silently skipped (`pipeline.py:218-237,252`). The CLI exposes no flag to disable checkpoints. Therefore two invocations that must do NEW work MUST use DIFFERENT output directories.
+
+Everything below is written to respect these three facts.
+
+## Pick paths first, then run
+
+```bash
+cd "$CLAUDE_PROJECT_DIR"
+TS=$(date +%Y%m%d-%H%M%S)
+SMOKE_DIR="evaluation/results/auto-bench-<name>-smoke-$TS"
+FULL_BASE="evaluation/results/auto-bench-<name>-full-$TS"
+```
+
+`$FULL_BASE` is a directory that contains one subdirectory per batch (or one subdirectory for the single-batch case) plus a merged summary JSON. Never write anything above `$FULL_BASE` from this skill.
+
+## Smoke test FIRST (always)
+
+Before any full run, prove the adapter is wired up. Explicit `--output-dir` makes the output path knowable and keeps the smoke run out of the full-run namespace:
+
+```bash
+uv run python -m evaluation.cli \
+  --dataset locomo \
+  --system <name> \
+  --smoke \
+  --smoke-messages 20 \
+  --smoke-questions 5 \
+  --output-dir "$SMOKE_DIR" \
+  --clean-groups
+```
+
+Interpret the smoke result:
+
+| Outcome | Action |
+|---|---|
+| Exits 0, `"$SMOKE_DIR/eval_results.json"` exists and is non-empty | Proceed to full run |
+| ImportError on candidate package | Stop. Write failure row to `seen_systems.json` with `status: failed`, `rejection_reason: "missing dep — not in evaluation-full"`. No PR; report to routine prompt. |
+| HTTP error from candidate service | Inspect docker logs: `docker compose -p auto-bench-<name> logs --tail 100`. If service never became healthy, mark `status: failed`, `rejection_reason: "service unhealthy on boot"`. |
+| `results` empty for all queries | Likely search method name wrong OR async indexing not awaited. Try adding `post_add_wait_seconds: 60` to config, re-run smoke ONCE (to a FRESH `$SMOKE_DIR` — don't reuse). If still empty: `status: failed`, `rejection_reason: "empty retrieval"`. |
+| OOM (container killed) | Stop. Mark `tier: oversize-infra`. No PR from this run; routine's main prompt will record this for the next iteration. |
+| Exits 0 but score is 0 for all 5 questions | Wire is correct but scoring is zero — proceed to full run anyway; humans will investigate via PR `[zero-score]` tag. |
+
+## Full run
+
+Only reachable if smoke passed. In both single- and multi-batch paths each CLI invocation gets its OWN `--output-dir` to avoid the checkpoint-skip bug described above.
+
+**Single-batch path** (when `BATCH_SIZE == 10`):
+
+```bash
+BATCH_DIR="$FULL_BASE/all"
+mkdir -p "$FULL_BASE"
+
+uv run python -m evaluation.cli \
+  --dataset locomo \
+  --system <name> \
+  --output-dir "$BATCH_DIR" \
+  --clean-groups
+```
+
+The per-batch `eval_results.json` lands at `"$BATCH_DIR/eval_results.json"`.
+
+**Multi-batch path** (when `BATCH_SIZE < 10`):
+
+LoCoMo has 10 conversations (indices 0..9). Slice into contiguous ranges using EXCLUSIVE upper bounds (to match the CLI's `--to-conv` semantics) and give each batch a distinct output subdirectory (to avoid the checkpoint carry-over):
+
+```bash
+NCONVS=10
+mkdir -p "$FULL_BASE"
+
+# Enumerate exclusive ranges: (0, BATCH_SIZE), (BATCH_SIZE, 2*BATCH_SIZE), ...
+BATCH_IDX=0
+for START in $(seq 0 "$BATCH_SIZE" $((NCONVS - 1))); do
+  END=$(( START + BATCH_SIZE ))
+  [ $END -gt $NCONVS ] && END=$NCONVS
+
+  BATCH_DIR="$FULL_BASE/batch-$BATCH_IDX-convs-$START-$((END - 1))"
+  echo "=== Batch $BATCH_IDX: convs [$START, $END) → $BATCH_DIR ==="
+
+  # Restart candidate stack to free transient memory between batches
+  if [ -d /tmp/candidate/<name> ]; then
+    docker compose -p auto-bench-<name> -f /tmp/candidate/<name>/docker-compose.yaml restart
+    sleep 20  # let the stack settle
+  fi
+
+  uv run python -m evaluation.cli \
+    --dataset locomo \
+    --system <name> \
+    --from-conv "$START" \
+    --to-conv "$END" \
+    --output-dir "$BATCH_DIR" \
+    --clean-groups
+
+  BATCH_IDX=$((BATCH_IDX + 1))
+done
+```
+
+Key invariants this loop enforces (and why the previous version was wrong):
+
+- `END = START + BATCH_SIZE` (NOT `START + BATCH_SIZE - 1`). The CLI treats `--to-conv` as exclusive, so the previous `-1` dropped the last conversation in every batch — a silent coverage bug.
+- Each batch writes to a distinct `$BATCH_DIR`, so the next batch's Pipeline reads an empty checkpoint and actually runs the stages instead of skipping them.
+- `$FULL_BASE` contains only batch subdirs; the merged summary goes one level up from each batch (see below), never overwriting a batch's own files.
+
+## Merge and completeness check
+
+Single-batch: read `"$FULL_BASE/all/eval_results.json"` directly.
+
+Multi-batch: merge the per-batch JSONs, then assert every expected conversation_id is present. Do the merge with a small Python block inside the skill — shell JSON manipulation is not worth the risk. Pass `$FULL_BASE` as an argv, not by heredoc interpolation (quoted heredoc deliberately disables substitution so the Python body stays literal):
+
+```bash
+uv run python - "$FULL_BASE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+full_base = Path(sys.argv[1])
+batch_dirs = sorted(p for p in full_base.iterdir() if p.is_dir() and p.name.startswith("batch-"))
+
+if not batch_dirs:  # single-batch fallback
+    batch_dirs = [full_base / "all"]
+
+merged = {"per_conversation": {}, "batch_files": []}
+for bd in batch_dirs:
+    f = bd / "eval_results.json"
+    if not f.exists():
+        raise SystemExit(f"missing batch result: {f}")
+    data = json.loads(f.read_text())
+    merged["batch_files"].append(str(f))
+    # The eval_results.json schema is harness-defined; do not invent field names here.
+    # Record the raw dict per batch and let the PR step reason over it.
+    merged.setdefault("batches", []).append({"batch_dir": str(bd), "eval": data})
+
+# Completeness check: we expect exactly 10 LoCoMo conversations covered.
+# Derive covered conv IDs from the loaded dataset slice used by each batch.
+# The harness-side per_conversation_metrics key is not guaranteed; rely on the
+# batch_dir names which encode the inclusive range we asked for.
+covered = set()
+for bd in batch_dirs:
+    if bd.name == "all":
+        covered |= set(range(10))
+    else:
+        # name format: batch-<i>-convs-<lo>-<hi>  (hi inclusive, per our mkdir)
+        parts = bd.name.split("-")
+        lo, hi = int(parts[-2]), int(parts[-1])
+        covered |= set(range(lo, hi + 1))
+
+expected = set(range(10))
+missing = sorted(expected - covered)
+if missing:
+    raise SystemExit(f"COVERAGE GAP: missing LoCoMo conversation indices {missing}. "
+                     "Do NOT publish this result.")
+
+(full_base / "merged_summary.json").write_text(json.dumps(merged, indent=2))
+print(f"Merged {len(batch_dirs)} batch(es); coverage complete (0..9).")
+PY
+```
+
+The completeness assertion is non-negotiable: if a batch silently dropped or skipped a conversation, the routine MUST abort here and open the PR with `[coverage-gap]` tag, with NO metrics in the body.
+
+After the merge passes, the PR step reads `"$FULL_BASE/merged_summary.json"` to compose the metrics table. Do not construct summaries from log output.
+
+Then compare against the top-3 already-integrated systems from `.auto_bench/seen_systems.json` (look for entries with `status: integrated` and a `last_benchmark` block). If `seen_systems.json` has no benchmark history for comparison yet, note that explicitly in the report body instead of inventing numbers.
+
+## Update seen_systems.json
+
+After the run completes (pass OR fail), append/update this candidate's entry:
+
+```json
+{
+  "name": "<name>",
+  "display_name": "<SystemName>",
+  "github": "<owner>/<repo>",
+  "first_seen": "<YYYY-MM-DD — today>",
+  "status": "candidate|failed",
+  "tier": "local-with-cloud-llm",
+  "memory_backend": "local",
+  "adapter_path": "evaluation/src/adapters/<name>_adapter.py",
+  "config_path": "evaluation/config/systems/<name>.yaml",
+  "infra_required": ["..."],
+  "estimated_ram_gb": <int>,
+  "last_run": {
+    "date": "<YYYY-MM-DD>",
+    "run_name": "<RUN_NAME>",
+    "smoke_result": "pass|fail",
+    "full_result": "pass|partial|fail",
+    "batch_mode": true|false,
+    "overall_score": <float or null>,
+    "notes": "<1–2 sentences>"
+  }
+}
+```
+
+Do NOT overwrite the file blindly — read it, update the single entry, write it back with 2-space indent.
+
+## Teardown (ALWAYS run at the end, even on failure)
+
+This is CRITICAL. Without teardown, the next routine run will OOM on startup.
+
+```bash
+# Stop candidate stack
+if [ -d /tmp/candidate/<name> ]; then
+  docker compose -p auto-bench-<name> -f /tmp/candidate/<name>/docker-compose.yaml down -v
+fi
+
+# Clean any orphaned candidate volumes (project-scoped only)
+docker volume ls --filter "label=com.docker.compose.project=auto-bench-<name>" -q | xargs -r docker volume rm
+
+# If EverOS stack was stopped earlier and the next step needs it, restart here.
+# For the auto-bench routine, leaving it stopped is fine — the next routine run will bring it up if needed.
+```
+
+Verify teardown:
+
+```bash
+docker ps --filter "label=com.docker.compose.project=auto-bench-<name>" -q | wc -l
+# Expect: 0
+```
+
+## Timeout budget
+
+The routine's overall wall-clock budget is ~90 minutes per candidate. Hard ceilings:
+
+- Smoke test: 10 minutes max. Kill and mark `status: failed` if exceeded.
+- Full run (single batch): 50 minutes max.
+- Full run (multi-batch): 75 minutes total max, even if some batches finished. Abort remaining batches and mark `full_result: partial`.
+- Teardown: 5 minutes max. If containers won't stop, `docker kill` and report in PR body.
+
+Use `timeout` wrappers:
+
+```bash
+timeout 600 uv run python -m evaluation.cli ... --smoke --output-dir "$SMOKE_DIR" ...
+timeout 3000 uv run python -m evaluation.cli ... --from-conv "$START" --to-conv "$END" --output-dir "$BATCH_DIR" ...
+```
+
+`$START` is inclusive, `$END` is exclusive — these match the CLI's semantics directly. Do not subtract one from `$END`.
+
+## What NOT to do in this skill
+
+- Do NOT write the PR body here. The routine's main prompt composes the PR.
+- Do NOT git commit — the main prompt batches commits after teardown.
+- Do NOT start EverOS's docker-compose.yaml for a routine candidate — candidates are local black-box integrations that don't need MongoDB/ES/Milvus/Redis. It's wasted RAM. (The only case EverOS infra is needed is for the native `evermemos` adapter, which is never a routine candidate.)
+- Do NOT pull candidate docker images on-the-fly if the setup script already did it — rely on the setup-script-cached images to avoid network blips.
+- Do NOT modify `evaluation/cli.py` or any harness file. If the CLI lacks a flag the routine needs, abort and file a note in the PR body instead.
+- Do NOT delete `evaluation/results/` — those are sources of truth.
+- Do NOT quote scores from training data, the candidate's paper, or log output. Only quote numbers that came from the `eval_results.json` you just wrote.

--- a/.claude/skills/write-eval-adapter/SKILL.md
+++ b/.claude/skills/write-eval-adapter/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: write-eval-adapter
+description: Use after discover-memory-frameworks has produced a candidate list. For each candidate (one at a time), this skill writes an adapter at `evaluation/src/adapters/<name>_adapter.py`, a system config at `evaluation/config/systems/<name>.yaml`, and a one-line addition to `evaluation/src/adapters/registry.py`. The adapter treats the candidate as a black-box local service (in-process SDK or localhost HTTP). Triggers when the routine prompt says "write adapter for <system>", "integrate <system>", or chains into this step after discovery. Does NOT run smoke tests or open PRs — that is the next skill's job.
+---
+
+# Write Eval Adapter
+
+This skill is the **second step** of every auto-bench routine run. Its job is to produce a working, registered adapter for ONE candidate memory framework at a time.
+
+## Naming clarification (important)
+
+The base class is called `OnlineAPIAdapter` for historical reasons. Do not read it as "cloud SaaS adapter". Its actual role is **black-box template method base class**: it provides three pieces of generic evaluation scaffolding that any system — local-SDK, local-HTTP, or SaaS — can share:
+
+1. Conversation-level concurrency control (`num_workers` semaphore).
+2. Dual-perspective handling for LoCoMo's `speaker_a` / `speaker_b`.
+3. `answer()` implementation built on `LLMProvider` (OpenRouter).
+
+The local-vs-SaaS distinction is enforced at discovery time (Rule 1 rejects SaaS candidates), not at the base-class level. Proof: `evermemos_api_adapter.py` is a local-HTTP adapter (`http://localhost:1995`) and inherits `OnlineAPIAdapter` — it is the canonical reference for this skill.
+
+**The structural reference for every new adapter is `evermemos_api_adapter.py`.** It shows the local-HTTP variant. For local-SDK candidates, use the same template-method overrides but construct the candidate's Python class in `__init__` instead of an `aiohttp.ClientSession`. Do NOT use `mem0_adapter.py` as a template — it targets Mem0's SaaS endpoint, which our Rule 1 already rejected.
+
+The alternative (inherit `BaseAdapter` directly) would drop the concurrency/perspective/answer scaffolding and force every new adapter to re-implement ~400 lines of harness plumbing. Not worth it.
+
+## When to use
+
+- After `discover-memory-frameworks` returns a non-empty `candidates` list.
+- For each candidate: invoke this skill once. Sequential, not parallel — each call touches `registry.py` and can race.
+- Do NOT use this skill on `evermemos` or any `status: integrated` system in `seen_systems.json`.
+- Do NOT use this skill to modify an existing adapter — this skill only creates new files.
+
+## Hard rules (the non-negotiables)
+
+**Rule A — Black-box local integration.** The new adapter MUST inherit from `OnlineAPIAdapter` (from `evaluation.src.adapters.online_base`) — see the naming clarification above. Do NOT inherit from `BaseAdapter` directly. Do NOT import anything from `src/memory_layer/` or `src/agentic_layer/` — those are EverMemOS internals reserved for the privileged `evermemos_adapter.py` path. The candidate must be treated as a black box: call its public SDK or HTTP endpoints only, never reach into EverMemOS primitives.
+
+**Rule B — Force LLM/embedding to OpenRouter.** The system config's `llm:` block MUST read `api_key: "${LLM_API_KEY}"` and `base_url: "${LLM_BASE_URL:https://openrouter.ai/api/v1}"` and `model: "openai/gpt-4.1-mini"` (the fairness baseline). If the candidate also has its own internal LLM/embedding config (e.g. writes calls to Ollama or a bundled local model), the adapter's `__init__` MUST override those at runtime using `os.environ["LLM_BASE_URL"]` and `os.environ["LLM_API_KEY"]` before constructing the candidate's client.
+
+**Rule C — No dependency changes.** If the candidate requires a new pip package that is not already in `pyproject.toml [project.optional-dependencies] evaluation-full`, STOP. Do not edit `pyproject.toml`. Write the adapter file skeleton anyway but mark the import with:
+
+```python
+try:
+    from candidatepkg import CandidateClient
+except ImportError:
+    raise ImportError(
+        "candidatepkg not installed. Add to pyproject.toml evaluation-full group "
+        "and open a separate PR before running this adapter."
+    )
+```
+
+Then the next skill (run-bench) will see the import error and emit a `[install-failed]` PR.
+
+## Adapter file template
+
+Write to `evaluation/src/adapters/<name>_adapter.py` (flat file, not subdir — the repo convention is flat files; only `evermemos/` and `openclaw/` are subdirs because they are privileged re-implementation paths).
+
+Use this skeleton. Fill in the four clearly-marked TODO blocks.
+
+```python
+"""
+<SystemName> Adapter — local black-box integration, OpenRouter-rewritten LLM.
+
+Auto-bench routine notes:
+- Inherits OnlineAPIAdapter template method.
+- <One paragraph, paraphrased from candidate README. No more than 15 words verbatim.>
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from rich.console import Console
+
+from evaluation.src.adapters.online_base import OnlineAPIAdapter
+from evaluation.src.adapters.registry import register_adapter
+from evaluation.src.core.data_models import Conversation, SearchResult
+
+
+@register_adapter("<name>")
+class <SystemName>Adapter(OnlineAPIAdapter):
+    """
+    <SystemName> adapter (local deployment, black-box integration).
+
+    Config example:
+    ```yaml
+    adapter: "<name>"
+    base_url: "http://localhost:<port>"  # or SDK-only: omit
+    api_key: ""
+    num_workers: 5
+    llm:
+      model: "openai/gpt-4.1-mini"
+      api_key: "${LLM_API_KEY}"
+      base_url: "${LLM_BASE_URL:https://openrouter.ai/api/v1}"
+    ```
+    """
+
+    def __init__(self, config: dict, output_dir: Path = None):
+        super().__init__(config, output_dir)
+
+        # --- TODO 1: force-rewrite candidate's LLM/embedding env (Rule B) ---
+        # If the candidate reads LLM config from env at import time, set env vars
+        # BEFORE importing / constructing its client. Example:
+        os.environ.setdefault("OPENAI_BASE_URL", os.environ.get("LLM_BASE_URL", ""))
+        os.environ.setdefault("OPENAI_API_KEY", os.environ.get("LLM_API_KEY", ""))
+
+        # --- TODO 2: construct the candidate client (Rule A, Rule C) ---
+        try:
+            from candidatepkg import CandidateClient  # type: ignore
+        except ImportError as e:
+            raise ImportError(
+                f"<name> not installed: {e}. Not in evaluation-full — add dependency "
+                "in a separate PR before running this adapter."
+            ) from e
+
+        self.base_url = str(config.get("base_url", "") or "").rstrip("/")
+        self.api_key = str(config.get("api_key", "") or "")
+        self.max_retries = int(config.get("max_retries", 3))
+        self.request_interval = float(config.get("request_interval", 0.0))
+
+        self.client = CandidateClient(
+            base_url=self.base_url or None,
+            api_key=self.api_key or None,
+            # If the client accepts llm overrides, wire them from config["llm"] here.
+        )
+        self.console = Console()
+        print(f"   <SystemName> client constructed (base_url={self.base_url or 'sdk-local'})")
+
+    # ---- Rule: most candidates do not support dual-perspective group chat. ----
+    #           Override only if the candidate explicitly supports multiple user_ids.
+    def _need_dual_perspective(self, speaker_a: str, speaker_b: str) -> bool:
+        return super()._need_dual_perspective(speaker_a, speaker_b)
+
+    # --- TODO 3: ingest (Stage 1 — add) ---
+    async def _add_user_messages(
+        self,
+        conv: Conversation,
+        messages: List[Dict[str, Any]],
+        speaker: str,
+        **kwargs: Any,
+    ) -> Any:
+        user_id = self._extract_user_id(conv, speaker=speaker)
+        progress = kwargs.get("progress")
+        task_id = kwargs.get("task_id")
+
+        for attempt in range(self.max_retries):
+            try:
+                # Call the candidate's ingest API. Shape guesses:
+                #   self.client.add(messages=messages, user_id=user_id, ...)
+                # or looped per-message:
+                #   for m in messages: self.client.ingest(user_id, m["content"], ...)
+                # Use whichever matches the candidate's public API.
+                await asyncio.to_thread(
+                    self.client.add,          # TODO: replace with real method name
+                    messages=messages,
+                    user_id=user_id,
+                )
+                break
+            except Exception as e:
+                if attempt < self.max_retries - 1:
+                    await asyncio.sleep(2 ** attempt)
+                    continue
+                raise
+
+        if progress is not None and task_id is not None:
+            progress.update(task_id, advance=len(messages))
+        if self.request_interval > 0:
+            await asyncio.sleep(self.request_interval)
+        return None
+
+    # --- TODO 4: retrieve (Stage 2 — search) ---
+    async def _search_single_user(
+        self,
+        query: str,
+        conversation_id: str,
+        user_id: str,
+        top_k: int,
+        **kwargs: Any,
+    ) -> List[Dict[str, Any]]:
+        raw = await asyncio.to_thread(
+            self.client.search,           # TODO: replace with real method name
+            query=query,
+            user_id=user_id,
+            top_k=top_k,
+        )
+
+        # Normalize to standard format required by OnlineAPIAdapter
+        out: List[Dict[str, Any]] = []
+        for item in (raw or []):
+            content = item.get("text") or item.get("memory") or item.get("content") or ""
+            ts = item.get("timestamp") or item.get("created_at") or ""
+            out.append({
+                "content": f"{ts}: {content}".strip(": ").strip() if ts else content,
+                "score": float(item.get("score", 0.0)),
+                "user_id": user_id,
+                "metadata": {"raw": item},
+            })
+        out.sort(key=lambda x: x.get("score", 0.0), reverse=True)
+        return out[: int(top_k)]
+
+    def _build_single_search_result(
+        self,
+        query: str,
+        conversation_id: str,
+        results: List[Dict[str, Any]],
+        user_id: str,
+        top_k: int,
+        **kwargs: Any,
+    ) -> SearchResult:
+        return SearchResult(
+            query=query,
+            conversation_id=conversation_id,
+            results=results[: int(top_k)],
+            retrieval_metadata={
+                "system": "<name>",
+                "top_k": int(top_k),
+                "dual_perspective": False,
+                "user_ids": [user_id],
+            },
+        )
+
+    def _build_dual_search_result(
+        self,
+        query: str,
+        conversation_id: str,
+        all_results: List[Dict[str, Any]],
+        results_a: List[Dict[str, Any]],
+        results_b: List[Dict[str, Any]],
+        speaker_a: str,
+        speaker_b: str,
+        speaker_a_user_id: str,
+        speaker_b_user_id: str,
+        top_k: int,
+        **kwargs: Any,
+    ) -> SearchResult:
+        # Reuse default template from prompts.yaml
+        speaker_a_text = "\n".join(r["content"] for r in results_a) if results_a else "(No memories found)"
+        speaker_b_text = "\n".join(r["content"] for r in results_b) if results_b else "(No memories found)"
+        template = self._prompts["online_api"].get("templates", {}).get("default", "")
+        formatted = template.format(
+            speaker_1=speaker_a,
+            speaker_1_memories=speaker_a_text,
+            speaker_2=speaker_b,
+            speaker_2_memories=speaker_b_text,
+        )
+        return SearchResult(
+            query=query,
+            conversation_id=conversation_id,
+            results=all_results,
+            retrieval_metadata={
+                "system": "<name>",
+                "top_k": int(top_k),
+                "dual_perspective": True,
+                "user_ids": [speaker_a_user_id, speaker_b_user_id],
+                "formatted_context": formatted,
+            },
+        )
+
+    def get_system_info(self) -> Dict[str, Any]:
+        return {
+            "name": "<SystemName>",
+            "type": "online_api",
+            "adapter": "<SystemName>Adapter",
+        }
+```
+
+### Two skeleton variants — pick at TODO 2
+
+**Variant A — Python SDK (in-process).** The candidate exposes a class you construct with kwargs. Pattern: `CandidateClient(...)` with in-memory storage, OR a client that talks to localhost via its own transport. Use `asyncio.to_thread(self.client.method, ...)` in `_add_user_messages` and `_search_single_user` to bridge sync SDKs. Example reference: the Mem0 local mode pattern (if it were implemented) or any `Memory()` class.
+
+**Variant B — HTTP API.** The candidate ships a docker-compose file with a REST server on `localhost:<port>`. Pattern: use `aiohttp.ClientSession` directly (see `evermemos_api_adapter.py` at `_request_json_with_retry`). Do NOT use `requests` — this codebase is async. Pass `base_url` and `api_key` through config.
+
+## System config template
+
+Write to `evaluation/config/systems/<name>.yaml`:
+
+```yaml
+# <SystemName> System Configuration (auto-generated by write-eval-adapter skill)
+
+name: "<name>"
+version: "1.0"
+description: "<SystemName> — <one-line paraphrased purpose>"
+
+adapter: "<name>"
+
+# <SystemName>-specific configuration
+base_url: "http://localhost:<port>"  # only for HTTP candidates; remove for SDK-only
+api_key: ""                           # most local candidates don't require auth
+max_retries: 3
+request_interval: 0.0
+
+# Concurrency (conversation-level; keep low until smoke test passes)
+num_workers: 5
+
+# Search configuration
+search:
+  top_k: 20
+
+# LLM configuration — FORCED to OpenRouter (Rule B, non-negotiable)
+llm:
+  provider: "openai"
+  model: "openai/gpt-4.1-mini"
+  api_key: "${LLM_API_KEY}"
+  base_url: "${LLM_BASE_URL:https://openrouter.ai/api/v1}"
+  temperature: 0
+  max_tokens: 32768
+
+answer:
+  max_retries: 3
+```
+
+If the candidate needs additional env vars (e.g. a license key required just for startup, not for inference), add them under a top-level `env:` key for documentation only. They must be actual env vars on the cloud container — do NOT hardcode values.
+
+## Register the adapter
+
+Add ONE line to `evaluation/src/adapters/registry.py` inside `_ADAPTER_MODULES`:
+
+```python
+"<name>": "evaluation.src.adapters.<name>_adapter",
+```
+
+Place it alongside the other `# Online API systems` comment block. Do not reorder existing entries. Do not remove any entry.
+
+## Batching contract for Rule 3 (RAM-aware split)
+
+The evaluation CLI supports `--from-conv I --to-conv J` natively on LoCoMo. The adapter does NOT need to do anything special for batching — the CLI's `--clean-groups` + `--from-conv`/`--to-conv` pair is sufficient, provided:
+
+- The adapter's `add()` is idempotent within a conversation (safe to re-run a conv on the same `user_id` if a batch is retried). Most external APIs are idempotent by message ID; if the candidate is not, include `clean_before_add: true` in its config and implement the cleanup in `prepare()` following `mem0_adapter.prepare`.
+- The adapter writes nothing to `evaluation/results/` directly — the harness owns that path.
+
+## Failure modes and what to record
+
+When writing the adapter, pre-decide how the next-step (run-bench) skill will classify a failure:
+
+| Symptom at smoke time | Cause | seen_systems.json status |
+|---|---|---|
+| `ImportError` on candidate package | Rule C: dep not in evaluation-full | `status: failed`, `rejection_reason: "not in evaluation-full dep group"` |
+| HTTP 401/403 on `base_url` | candidate requires auth that this env can't provide | `status: failed`, `rejection_reason: "auth required"` |
+| `AttributeError: 'CandidateClient' has no attribute 'add'` | TODO 2/3 method names wrong | fix in-place, re-run smoke |
+| Candidate returns empty results for all queries on `--smoke` | search API wired incorrectly OR candidate requires background indexing | try `post_add_wait_seconds: 60` in config; if still empty → `status: failed` |
+| OOM during smoke with `--smoke-messages 20` | candidate has hidden infra requirement | mark `tier: oversize-infra`, do NOT open PR from this run |
+| Candidate works but scores 0 on LoCoMo | adapter is wired but output format mismatches | leave adapter, open PR with `[zero-score]` tag so humans can debug |
+
+## What NOT to do in this skill
+
+- Do NOT run smoke tests. That is the next skill.
+- Do NOT open a PR. The routine's main prompt opens the PR at the end.
+- Do NOT git commit. The routine's main prompt batches commits.
+- Do NOT touch `evermemos_adapter.py`, `evermemos/` subdir, or `openclaw/` subdir.
+- Do NOT modify existing system YAMLs.
+- Do NOT guess the candidate's API method names — read the README and at least one example from the candidate repo. If the README is ambiguous, prefer the lowest-risk guess (`.add()` for ingest, `.search()` for retrieval) but note the uncertainty in a `# TODO(auto-bench):` comment.
+- Do NOT add comments explaining the 4-stage pipeline inside the adapter — the base class docstring already covers it. Keep the adapter file tight.
+- Do NOT copy `evermemos_adapter.py` as a starting point — it's the privileged re-implementation path and does not inherit from `OnlineAPIAdapter`. Use `evermemos_api_adapter.py` as the reference instead.
+- Do NOT mirror `mem0_adapter.py` — it targets Mem0's SaaS endpoint, which violates Rule 1. Rule 1 was already enforced at the discovery step, so any candidate reaching this skill is local; use the local reference.

--- a/.gitignore
+++ b/.gitignore
@@ -206,7 +206,12 @@ src/memory_layer/memory_extractor/profile_memory_extractor keep llm merge.py
 #LLM related
 AGENTS.mk
 docs/api_docs/profile_extraction_fields.md
-.claude/
+.claude/*
+# Routine-consumed files must be tracked; per-user settings stay ignored via .claude/*.
+!.claude/skills/
+!.claude/rules/
+!.claude/setup.sh
+!.claude/ROUTINE_PROMPT.md
 .cursor/*
 
 #tmp_data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,7 @@ pyright                       # Type check
 - All I/O is async - use `await`
 - Multi-tenant system - data is tenant-scoped
 - Prompts in `src/memory_layer/prompts/` (EN/ZH)
+
+## Auto-Bench Routine
+
+Sessions started by the auto-bench routine must follow `@.claude/rules/auto-bench-routine.md`. Normal interactive sessions ignore it.


### PR DESCRIPTION
## Summary

- Adds a Claude Code Routine (weekly) that discovers new memory frameworks, integrates each one as a black-box adapter against the existing `evaluation/` harness, runs LoCoMo inside the cloud container's 16 GB RAM budget, and opens draft PRs with results.
- Three non-negotiable rules codified in `.claude/rules/auto-bench-routine.md`: local-memory-backend only, LLM/embedding forced to OpenRouter, RAM-aware batching.
- Harness-correct batching: per-batch explicit `--output-dir` (dodges the Pipeline's checkpoint-skip behavior at `pipeline.py:218-237`), `--to-conv` treated as exclusive (`cli.py:107`), completeness assertion on merged output before publishing results.

## Files

- `.claude/skills/{discover-memory-frameworks,write-eval-adapter,run-bench-with-docker-stack}/SKILL.md`
- `.claude/rules/auto-bench-routine.md`
- `.claude/ROUTINE_PROMPT.md` — prompt to paste into routine config
- `.claude/setup.sh` — cloud-container bootstrap
- `.auto_bench/seen_systems.json` — dedup registry (pre-seeded with 5 known systems)
- `CLAUDE.md` — one-line reference to the new rules file
- `.gitignore` — whitelist routine-consumed `.claude/*` paths while keeping user-local settings ignored

## Test plan

- [ ] Paste `.claude/ROUTINE_PROMPT.md` into a new routine at claude.ai/code/routines with NO schedule
- [ ] First run in DRY-RUN mode (clause in the prompt) — only discover + write-adapter, no bench, no PR
- [ ] Inspect the adapter file diff and system YAML printed to the session log
- [ ] Remove dry-run clause; real-run 1–2 times manually
- [ ] Verify per-batch output dirs are distinct and merged_summary.json asserts coverage
- [ ] Enable weekly schedule (Sunday evening) only after above passes

## Review history

Codex adversarial review caught three high-severity bugs in the first draft (checkpoint reuse, wrong `eval_results.json` path, off-by-one `--to-conv` math). All three are fixed in this branch; see the "Output-path contract" section in `run-bench-with-docker-stack/SKILL.md` for the harness-level facts they depend on.

Created by automated routine setup work — draft for review.