### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # EverCore (pip/uv)
+  - package-ecosystem: pip
+    directory: /methods/EverCore
+    schedule:
+      interval: weekly
+    groups:
+      python-deps:
+        patterns: ["*"]
+
+  # EvoAgentBench website (npm)
+  - package-ecosystem: npm
+    directory: /benchmarks/EvoAgentBench/website
+    schedule:
+      interval: weekly
+    groups:
+      npm-deps:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Add Dependabot weekly update configuration for GitHub Actions, EverCore Python dependencies, and EvoAgentBench website npm dependencies
- Group updates by ecosystem to keep dependency PRs focused

## Verification
- Checked Dependabot config shape locally
- Ran `git diff --cached --check` before commit