### PR TITLE
docs: verify EverCore quickstart path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 # Project specific
 outputs/
 .pytest_cache/
+methods/EverCore/docker-compose.override.yaml
 
 evaluation/static_memory_evaluation/logs/
 evaluation/static_memory_evaluation/retrieval/

--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ The fastest way to run a memory system locally is to start with EverCore:
 ```bash
 cd methods/EverCore
 
+# Requires Python 3.12 and Docker.
+
 # Start Docker services
 docker compose up -d
 
@@ -414,29 +416,45 @@ Server runs at `http://localhost:1995` · [Full Setup Guide](methods/EverCore/do
 Store and retrieve memories with simple Python code:
 
 ```python
+import os
 import requests
 
-API_BASE = "http://localhost:1995/api/v1"
+API_BASE = os.getenv("EVERCORE_API_BASE", "http://localhost:1995/api/v1")
 
 # 1. Store a conversation memory
-requests.post(f"{API_BASE}/memories", json={
-    "message_id": "msg_001",
-    "create_time": "2025-02-01T10:00:00+00:00",
-    "sender": "user_001",
-    "content": "I love playing soccer on weekends"
-})
+add_payload = {
+    "user_id": "user_001",
+    "session_id": "quickstart_session",
+    "messages": [
+        {
+            "message_id": "msg_001",
+            "sender_id": "user_001",
+            "sender_name": "User",
+            "role": "user",
+            "timestamp": 1738404000000,
+            "content": "I love playing soccer on weekends",
+        }
+    ],
+}
+add_result = requests.post(f"{API_BASE}/memories", json=add_payload)
+add_result.raise_for_status()
+add_result = add_result.json()
+print(add_result["data"]["status"])
 
 # 2. Search for relevant memories
-response = requests.get(f"{API_BASE}/memories/search", json={
+search_payload = {
     "query": "What sports does the user like?",
-    "user_id": "user_001",
+    "method": "hybrid",
     "memory_types": ["episodic_memory"],
-    "retrieve_method": "hybrid"
-})
+    "top_k": 5,
+    "filters": {"user_id": "user_001"},
+}
+search_result = requests.post(f"{API_BASE}/memories/search", json=search_payload)
+search_result.raise_for_status()
+search_result = search_result.json()
 
-result = response.json().get("result", {})
-for memory_group in result.get("memories", []):
-    print(f"Memory: {memory_group}")
+for episode in search_result["data"]["episodes"]:
+    print(episode["episode"])
 ```
 
 [More Examples](methods/EverCore/docs/usage/USAGE_EXAMPLES.md) · [API Reference](https://docs.evermind.ai/api-reference/introduction) · [Interactive Demos](methods/EverCore/docs/usage/DEMOS.md)


### PR DESCRIPTION
## Summary
- update the EverCore README basic usage snippet to use the actual POST JSON API contract
- add an explicit Python/Docker prerequisite note in Quick Start
- ignore local docker-compose override files used for machine-specific Docker fixes

## Verification
- extracted and ran the README Basic Usage Python block locally against EverCore API
- confirmed POST /api/v1/memories and POST /api/v1/memories/search returned HTTP 200
- ran git diff --check