### PR TITLE
chore: ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ AGENTS.mk
 docs/api_docs/profile_extraction_fields.md
 .claude/
 .cursor/*
+CLAUDE.local.md
 
 #tmp_data
 demo/memcell_outputs/


### PR DESCRIPTION
## Summary
- Add `CLAUDE.local.md` to `.gitignore` so the private project-local instructions file is no longer tracked as untracked clutter.

## Why
`CLAUDE.local.md` holds personal, machine-local Claude Code instructions and should not be committed to the repo.

## Verification
- `git check-ignore CLAUDE.local.md` confirms the file is now ignored.