### PR TITLE
[codex] simplify README launch highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 <br>
 
 - [What is EverOS](#what-is-everos)
-- [EverMind ecosystem](#evermind-ecosystem)
 - [Architecture at a glance](#architecture-at-a-glance)
 - [Quick start](#quick-start)
 - [Storage layout](#storage-layout)
@@ -31,6 +30,7 @@
 - [Documentation](#documentation)
 - [Use Cases](#use-cases)
 - [Stay Tuned](#stay-tuned)
+- [EverMind ecosystem](#evermind-ecosystem)
 - [Contributing](#contributing)
 
 <br>
@@ -45,48 +45,6 @@ EverOS is an open-source Python framework that turns conversations, agent trajec
 1. **Markdown as Source of Truth** — All memory persists as plain `.md` files. Open, edit, grep, version with Git, view in Obsidian. No black-box database lock-in.
 2. **Lightweight three-piece storage** — `Markdown` files (truth) + `SQLite` (state/queue) + `LanceDB` (vector + BM25 + scalar). No MongoDB / Elasticsearch / Milvus / Redis / Kafka required.
 3. **[EverAlgo](https://github.com/EverMind-AI/EverAlgo) as pure algorithm library** — Memory extraction algorithms are decoupled into a separate library; this project orchestrates and persists.
-
-<br>
-
-## EverMind ecosystem
-
-EverMind is an open-source ecosystem for long-term memory, self-evolving agents, and memory evaluation. EverOS is the core runtime architecture; EverMemOS is the paper and research line carrying our strongest memory-system benchmark runs; EverAlgo supplies the next-generation algorithms that make the system modular and reusable.
-
-<table>
-<tr>
-<th colspan="2">EverMind Open-Source Ecosystem</th>
-</tr>
-<tr>
-<td><strong>Core memory architecture</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> / EverMemOS - the local memory operating system and research-backed runtime for agent and user memory.</td>
-</tr>
-<tr>
-<td><strong>Algorithm engine</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
-</tr>
-<tr>
-<td><strong>Alternative architecture</strong></td>
-<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with its own benchmark-backed topic -> episode -> fact retrieval method.</td>
-</tr>
-<tr>
-<td><strong>Benchmarks</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
-</tr>
-<tr>
-<td><strong>Long-context research</strong></td>
-<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
-</tr>
-<tr>
-<td><strong>Personal memory layer</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
-</tr>
-<tr>
-<td><strong>Developer integrations</strong></td>
-<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
-</tr>
-</table>
-
-Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
 
 <br>
 
@@ -564,6 +522,48 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 Star the repo or join the community links above to follow new architecture methods, benchmark releases, and memory-enabled use cases.
 
 ![star us gif](https://github.com/user-attachments/assets/0c512570-945a-483a-9f47-8e067bd34484)
+
+<br>
+
+## EverMind ecosystem
+
+EverMind is an open-source ecosystem for long-term memory, self-evolving agents, and memory evaluation. EverOS is the core runtime architecture; EverMemOS is the paper and research line carrying our strongest memory-system benchmark runs; EverAlgo supplies the next-generation algorithms that make the system modular and reusable.
+
+<table>
+<tr>
+<th colspan="2">EverMind Open-Source Ecosystem</th>
+</tr>
+<tr>
+<td><strong>Core memory architecture</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> / EverMemOS - the local memory operating system and research-backed runtime for agent and user memory.</td>
+</tr>
+<tr>
+<td><strong>Algorithm engine</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
+</tr>
+<tr>
+<td><strong>Alternative architecture</strong></td>
+<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with its own benchmark-backed topic -> episode -> fact retrieval method.</td>
+</tr>
+<tr>
+<td><strong>Benchmarks</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
+</tr>
+<tr>
+<td><strong>Long-context research</strong></td>
+<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
+</tr>
+<tr>
+<td><strong>Personal memory layer</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
+</tr>
+<tr>
+<td><strong>Developer integrations</strong></td>
+<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
+</tr>
+</table>
+
+Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@
 
 <br>
 
-- [EverOS 1.0 highlights](#everos-10-highlights)
-- [What is EverOS](#what-is-everos)
-- [Quick start](#quick-start)
-- [Architecture at a glance](#architecture-at-a-glance)
-- [Storage layout](#storage-layout)
+- [EverOS 1.0.0 Highlights](#everos-100-highlights)
+- [What Is EverOS](#what-is-everos)
+- [Quick Start](#quick-start)
+- [Architecture At A Glance](#architecture-at-a-glance)
+- [Storage Layout](#storage-layout)
 - [Features](#features)
-- [Project structure](#project-structure)
+- [Project Structure](#project-structure)
 - [Documentation](#documentation)
 - [Use Cases](#use-cases)
 - [Stay Tuned](#stay-tuned)
-- [EverMind ecosystems](#evermind-ecosystems)
+- [EverMind Ecosystems](#evermind-ecosystems)
 - [Contributing](#contributing)
 
 <br>
@@ -39,11 +39,11 @@
 </details>
 
 
-## EverOS 1.0 highlights
+## EverOS 1.0.0 Highlights
 
 > [!IMPORTANT]
 >
-> **EverOS 1.0 is a major release for self-evolving memory.** It brings a
+> **EverOS 1.0.0 is a major release for self-evolving memory.** It brings a
 > local-first runtime, Markdown as the source of truth, hybrid retrieval,
 > multimodal ingestion, user and agent memory scopes, and modular algorithms
 > through [EverAlgo](https://github.com/EverMind-AI/EverAlgo).
@@ -54,51 +54,51 @@
 <table>
 <tr>
 <td width="33%" valign="top">
-<strong>Markdown-first memory</strong><br>
+<strong>Markdown-First Memory</strong><br>
 Memory is persisted as plain Markdown: visible, auditable, hand-editable,
 Git-friendly, and owned by the user.
 </td>
 <td width="33%" valign="top">
-<strong>Lightweight local stack</strong><br>
+<strong>Lightweight Local Stack</strong><br>
 Install with Python. SQLite tracks runtime state; LanceDB powers vector,
 BM25, and scalar-filter retrieval locally.
 </td>
 <td width="33%" valign="top">
-<strong>Layered memory model</strong><br>
+<strong>Layered Memory Model</strong><br>
 User memory and agent memory are first-class today. Wiki-style knowledge
 is the next layer in the roadmap.
 </td>
 </tr>
 <tr>
 <td width="33%" valign="top">
-<strong>Self-evolving agents</strong><br>
+<strong>Self-Evolving Agents</strong><br>
 Agent memory can extract reusable cases and skills from repeated
 experience, so workflows become smarter over time.
 </td>
 <td width="33%" valign="top">
-<strong>Multimodal ingestion</strong><br>
+<strong>Multimodal Ingestion</strong><br>
 Text, image, audio, documents, PDF, HTML, and email can be parsed into
 memory through the optional multimodal pipeline.
 </td>
 <td width="33%" valign="top">
-<strong>Online and offline strategy control</strong><br>
+<strong>Online And Offline Strategy Control</strong><br>
 Online extraction and offline evolution stay separate, with configurable
 prompts and models at each step. Dreaming is coming next.
 </td>
 </tr>
 <tr>
 <td width="33%" valign="top">
-<strong>Orthogonal memory scope</strong><br>
+<strong>Orthogonal Memory Scope</strong><br>
 Owner, memory type, and scope are independent: search by user, agent,
 app, project, session, and structured filters.
 </td>
 <td width="33%" valign="top">
-<strong>Progressive disclosure</strong><br>
+<strong>Progressive Disclosure</strong><br>
 Readable memory surfaces stay simple while deeper facts, cases, and
 skills remain available.
 </td>
 <td width="33%" valign="top">
-<strong>Modular by design</strong><br>
+<strong>Modular By Design</strong><br>
 EverAlgo owns algorithms; EverOS owns runtime, persistence, online flows,
 and offline evolution.
 </td>
@@ -113,7 +113,7 @@ and offline evolution.
 </div>
 
 
-## What is EverOS
+## What Is EverOS
 
 EverOS is an open-source Python framework for long-term memory in AI
 agents and user chats. It turns conversations, agent trajectories, and
@@ -133,7 +133,7 @@ The system is built around three boundaries:
 
 </div>
 
-## Quick start
+## Quick Start
 
 ### 1. Install EverOS
 
@@ -142,7 +142,7 @@ uv pip install everos
 # or: pip install everos
 ```
 
-### 2. Initialize configuration
+### 2. Initialize Configuration
 
 Generate a starter `.env` file, then fill the API key fields shown in
 the generated comments.
@@ -154,7 +154,7 @@ everos init
 `everos init` writes `./.env` by default. Use `everos init --xdg` to
 write `${XDG_CONFIG_HOME:-~/.config}/everos/.env` instead.
 
-### 3. Start the server
+### 3. Start The Server
 
 ```bash
 everos --help
@@ -170,7 +170,7 @@ at any of them.
 For a step-by-step walkthrough (add a conversation, flush, search, then
 read the markdown), see [QUICKSTART.md](QUICKSTART.md).
 
-### Optional: ingest multimodal files
+### Optional: Ingest Multimodal Files
 
 To ingest non-text content (image / pdf / audio / office documents)
 through `/api/v1/memory/add` `content` items, install the optional
@@ -199,7 +199,7 @@ brew install --cask libreoffice              # macOS
 sudo apt-get install -y libreoffice          # Debian / Ubuntu
 ```
 
-### For contributors
+### For Contributors
 
 ```bash
 git clone https://github.com/EverMind-AI/EverOS.git
@@ -219,7 +219,7 @@ make test
 
 </div>
 
-## Architecture at a glance
+## Architecture At A Glance
 
 ```
 ┌───────────────────────────────────────────────┐
@@ -245,7 +245,7 @@ DDD 5 layers, single-direction dependency. See [docs/architecture.md](docs/archi
 
 </div>
 
-## Storage layout
+## Storage Layout
 
 ```
 ~/.everos/
@@ -295,7 +295,7 @@ quietly alongside.
 
 </div>
 
-## Project structure
+## Project Structure
 
 ```
 everos/                        # repo root
@@ -349,7 +349,7 @@ external demos or integrations you can study and adapt.
 
 [![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
 
-#### Reunite - Find with EverOS
+#### Reunite - Find With EverOS
 
 Parents describe what they remember. Children describe what they recall. Reunite uses semantic memory to surface the connections.
 
@@ -374,7 +374,7 @@ Browser-native hive-mind for CLI coding agents - Claude Code, Codex, Gemini, and
 
 [![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
 
-#### AI Coding Assistants with EverOS
+#### AI Coding Assistants With EverOS
 
 Universal long-term memory layer for AI coding assistants, powered by EverOS.
 
@@ -399,7 +399,7 @@ An agentic AI system that learns from scientist interaction to inspect, analyze,
 
 ![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
 
-#### Rokid AI Assistant with EverOS
+#### Rokid AI Assistant With EverOS
 
 Connect to EverOS within Rokid Glasses enabling long-term memory for all of your smart activities.
 
@@ -410,7 +410,7 @@ Coming soon
 
 ![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
 
-#### Creative Assistant with Memory
+#### Creative Assistant With Memory
 
 Creative assistant with long-term memory, so your creative context stays available across sessions.
 
@@ -479,7 +479,7 @@ Build AI that feels. Open-source persona engine - personality emerges from neura
 
 [![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
 
-#### Browser Agent for Personal Memory
+#### Browser Agent For Personal Memory
 
 Ruminer brings persistent memory to a browser agent so it can carry personal context across web tasks.
 
@@ -490,7 +490,7 @@ Ruminer brings persistent memory to a browser agent so it can carry personal con
 
 [![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
 
-#### EverMem Sync with EverOS
+#### EverMem Sync With EverOS
 
 One command to connect any AI coding CLI to EverMemOS long-term memory.
 
@@ -521,7 +521,7 @@ MCO equips your primary agent with an agent team that can work together to solve
 
 [![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
 
-#### Study Buddy with Self-Evolving Memory
+#### Study Buddy With Self-Evolving Memory
 
 Study proactively with an agent that has self-evolving memory.
 
@@ -571,7 +571,7 @@ An iOS app where users create, nurture, and live with a personalized AI companio
 
 [![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
 
-#### AI Wearable with Memory
+#### AI Wearable With Memory
 
 A context-native AI wearable that listens to everyday life and converts conversations into memory.
 
@@ -601,7 +601,7 @@ Archived pre-1.0.0 plugin reference. New integrations should use the EverOS 1.0.
 
 [![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
 
-#### Live2D Character with Memory
+#### Live2D Character With Memory
 
 Add long-term memory to a real-time Live2D character, powered by [TEN Framework](https://github.com/TEN-framework/ten-framework).
 
@@ -614,7 +614,7 @@ Add long-term memory to a real-time Live2D character, powered by [TEN Framework]
 
 [![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
 
-#### Computer-Use with Memory
+#### Computer-Use With Memory
 
 Run screenshot-based analysis with computer-use and store the results in memory.
 
@@ -625,7 +625,7 @@ Run screenshot-based analysis with computer-use and store the results in memory.
 
 [![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](use-cases/game-of-throne-demo)
 
-#### Game of Thrones Memories
+#### Game Of Thrones Memories
 
 A demonstration of AI memory infrastructure through an interactive Q&A experience with *A Game of Thrones*.
 
@@ -679,7 +679,7 @@ Star the repo or join the community links above to follow new architecture metho
 
 </div>
 
-## EverMind ecosystems
+## EverMind Ecosystems
 
 EverMind is an open-source ecosystem for long-term memory, self-evolving agents, and memory evaluation. EverOS is the core runtime architecture; EverMemOS is the paper and research line carrying our strongest memory-system benchmark runs; EverAlgo supplies the next-generation algorithms that make the system modular and reusable.
 
@@ -688,15 +688,15 @@ EverMind is an open-source ecosystem for long-term memory, self-evolving agents,
 <th colspan="2">EverMind Open-Source Ecosystem</th>
 </tr>
 <tr>
-<td><strong>Core memory architecture</strong></td>
+<td><strong>Core Memory Architecture</strong></td>
 <td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> / EverMemOS - the local memory operating system and research-backed runtime for agent and user memory.</td>
 </tr>
 <tr>
-<td><strong>Algorithm engine</strong></td>
+<td><strong>Algorithm Engine</strong></td>
 <td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
 </tr>
 <tr>
-<td><strong>Alternative architecture</strong></td>
+<td><strong>Alternative Architecture</strong></td>
 <td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with its own benchmark-backed topic -> episode -> fact retrieval method.</td>
 </tr>
 <tr>
@@ -704,15 +704,15 @@ EverMind is an open-source ecosystem for long-term memory, self-evolving agents,
 <td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
 </tr>
 <tr>
-<td><strong>Long-context research</strong></td>
+<td><strong>Long-Context Research</strong></td>
 <td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
 </tr>
 <tr>
-<td><strong>Personal memory layer</strong></td>
+<td><strong>Personal Memory Layer</strong></td>
 <td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
 </tr>
 <tr>
-<td><strong>Developer integrations</strong></td>
+<td><strong>Developer Integrations</strong></td>
 <td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![banner-gif](https://github.com/user-attachments/assets/0bf97efd-580f-4a53-a2a2-58d6daea7290)
+![EverOS banner](https://github.com/EverMind-AI/EverOS/releases/download/v1.0.0/everos-readme-banner.jpg)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>

--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@
   <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [Blog](https://evermind.ai/blogs)
+[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [Blog](https://evermind.ai/blogs) · [中文](README.zh-CN.md)
 
 </div>
 
 
 <br>
 
-<details open>
+<details>
   <summary><kbd>Table of Contents</kbd></summary>
 
 <br>
 
-- [What Is EverOS](#what-is-everos)
 - [EverOS 1.0.0 Highlights](#everos-100-highlights)
+- [What Is EverOS](#what-is-everos)
 - [Quick Start](#quick-start)
 - [Architecture At A Glance](#architecture-at-a-glance)
 - [Storage Layout](#storage-layout)
@@ -37,33 +37,6 @@
 <br>
 
 </details>
-
-
-## What Is EverOS
-
-EverOS is an open-source Python framework for self-evolving long-term
-memory across agents and platforms. It gives makers one portable memory
-layer for every agent they use - Claude Code, Codex, OpenClaw, Hermes,
-and more - so context, decisions, files, and trajectories can follow the
-work instead of staying trapped in one tool.
-
-EverOS stores conversations, agent trajectories, and files as readable
-Markdown, then syncs local SQLite and LanceDB indexes for fast retrieval.
-Agents can reuse past cases and skills, improve from repeated workflows,
-and become more proactive over time.
-
-The system is built around three boundaries:
-
-1. **Memory content stays readable** - Markdown is the durable source of truth.
-2. **Runtime state stays local** - SQLite tracks state and LanceDB handles vector, BM25, and scalar-filter search.
-3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
-
-<br>
-<div align="right">
-
-[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
-
-</div>
 
 
 ## EverOS 1.0.0 Highlights
@@ -131,6 +104,33 @@ and offline evolution.
 </td>
 </tr>
 </table>
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+
+## What Is EverOS
+
+EverOS is an open-source Python framework for self-evolving long-term
+memory across agents and platforms. It gives makers one portable memory
+layer for every agent they use - Claude Code, Codex, OpenClaw, Hermes,
+and more - so context, decisions, files, and trajectories can follow the
+work instead of staying trapped in one tool.
+
+EverOS stores conversations, agent trajectories, and files as readable
+Markdown, then syncs local SQLite and LanceDB indexes for fast retrieval.
+Agents can reuse past cases and skills, improve from repeated workflows,
+and become more proactive over time.
+
+The system is built around three boundaries:
+
+1. **Memory content stays readable** - Markdown is the durable source of truth.
+2. **Runtime state stays local** - SQLite tracks state and LanceDB handles vector, BM25, and scalar-filter search.
+3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
 
 <br>
 <div align="right">
@@ -678,6 +678,10 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 Star the repo or join the community links above to follow new architecture methods, benchmark releases, memory-enabled use cases, Wiki-style memory, and Dreaming updates.
 
 ![star us gif](https://github.com/user-attachments/assets/0c512570-945a-483a-9f47-8e067bd34484)
+
+### Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/EverOS&type=Date)](https://www.star-history.com/#EverMind-AI/EverOS&Date)
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![EverOS banner](https://github.com/user-attachments/assets/fadd7680-544f-40bc-ba8a-34ad4723fd19)
+![EverOS banner](https://github.com/EverMind-AI/EverOS/releases/download/v1.0.0/everos-readme-banner.jpg)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 <br>
 
 - [What is EverOS](#what-is-everos)
+- [EverMind ecosystem](#evermind-ecosystem)
 - [Architecture at a glance](#architecture-at-a-glance)
 - [Quick start](#quick-start)
 - [Storage layout](#storage-layout)
@@ -44,6 +45,48 @@ EverOS is an open-source Python framework that turns conversations, agent trajec
 1. **Markdown as Source of Truth** — All memory persists as plain `.md` files. Open, edit, grep, version with Git, view in Obsidian. No black-box database lock-in.
 2. **Lightweight three-piece storage** — `Markdown` files (truth) + `SQLite` (state/queue) + `LanceDB` (vector + BM25 + scalar). No MongoDB / Elasticsearch / Milvus / Redis / Kafka required.
 3. **[EverAlgo](https://github.com/EverMind-AI/EverAlgo) as pure algorithm library** — Memory extraction algorithms are decoupled into a separate library; this project orchestrates and persists.
+
+<br>
+
+## EverMind ecosystem
+
+EverMind is an open-source ecosystem for long-term memory, self-evolving agents, and memory evaluation. EverOS is the core runtime architecture; EverMemOS is the paper and research line carrying our strongest memory-system benchmark runs; EverAlgo supplies the next-generation algorithms that make the system modular and reusable.
+
+<table>
+<tr>
+<th colspan="2">EverMind Open-Source Ecosystem</th>
+</tr>
+<tr>
+<td><strong>Core memory architecture</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> / EverMemOS - the local memory operating system and research-backed runtime for agent and user memory.</td>
+</tr>
+<tr>
+<td><strong>Algorithm engine</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
+</tr>
+<tr>
+<td><strong>Alternative architecture</strong></td>
+<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with its own benchmark-backed topic -> episode -> fact retrieval method.</td>
+</tr>
+<tr>
+<td><strong>Benchmarks</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
+</tr>
+<tr>
+<td><strong>Long-context research</strong></td>
+<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
+</tr>
+<tr>
+<td><strong>Personal memory layer</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
+</tr>
+<tr>
+<td><strong>Developer integrations</strong></td>
+<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
+</tr>
+</table>
+
+Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 
 <br>
 
-- [EverOS 1.0.0 in 30 seconds](#everos-100-in-30-seconds)
 - [What is EverOS](#what-is-everos)
 - [Quick start](#quick-start)
 - [Architecture at a glance](#architecture-at-a-glance)
@@ -29,9 +28,9 @@
 - [Features](#features)
 - [Project structure](#project-structure)
 - [Documentation](#documentation)
-- [Use Cases](#use-cases)
 - [Stay Tuned](#stay-tuned)
-- [EverMind ecosystem](#evermind-ecosystem)
+- [Use Cases](#use-cases)
+- [Related EverMind repositories](#related-evermind-repositories)
 - [Contributing](#contributing)
 
 <br>
@@ -39,37 +38,13 @@
 </details>
 
 
-## EverOS 1.0.0 in 30 seconds
-
-EverOS gives AI agents a local memory system that developers can inspect,
-edit, rebuild, and extend.
-
-<table>
-<tr>
-<td width="50%" valign="top">
-<strong>Memory you can read</strong><br>
-Plain Markdown is the source of truth. SQLite and LanceDB are local,
-rebuildable indexes.
-</td>
-<td width="50%" valign="top">
-<strong>Easy to run locally</strong><br>
-Install with Python. No Docker, MongoDB, Elasticsearch, Redis, Kafka, or
-hosted database is required.
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-<strong>User and agent memory</strong><br>
-Store profiles, episodes, task cases, and skills with scoped search by
-user, agent, app, project, and session.
-</td>
-<td width="50%" valign="top">
-<strong>Evolving, multimodal memory</strong><br>
-Ingest text, image, audio, docs, PDF, HTML, and email. Online extraction
-and offline evolution are configurable; Reflection and LLM Wiki are next.
-</td>
-</tr>
-</table>
+> [!NOTE]
+>
+> **EverOS 1.0.0 is here.** The refactor is Markdown-first, lightweight
+> enough to run locally with Python, and built around scoped user and
+> agent memory. It supports local SQLite state, LanceDB hybrid retrieval,
+> multimodal ingestion, configurable online/offline memory strategies,
+> and modular algorithms through [EverAlgo](https://github.com/EverMind-AI/EverAlgo).
 
 <br>
 
@@ -262,42 +237,6 @@ everos/                        # repo root
 
 <br>
 
-## Use Cases
-
-EverOS is already being used across AI coding, personal memory, creative
-assistants, games, browser agents, and research workflows. The README keeps
-the path short; the full showcase lives in [docs/use-cases.md](docs/use-cases.md).
-
-<table>
-<tr>
-<td width="33%" valign="top">
-<strong>AI coding memory</strong><br>
-Persistent context for coding assistants and multi-agent engineering workflows.
-<br><br>
-<a href="https://github.com/tt-a1i/evermemos-mcp">Coding assistant memory</a> ·
-<a href="https://github.com/tt-a1i/hive">Hive</a>
-</td>
-<td width="33%" valign="top">
-<strong>Personal memory products</strong><br>
-Memory for companions, browser agents, wearables, education, and daily life.
-<br><br>
-<a href="https://evermind.ai/usecase_reunite">Reunite</a> ·
-<a href="https://github.com/TonyLiangDesign/MemoCare">MemoCare</a>
-</td>
-<td width="33%" valign="top">
-<strong>Research and demos</strong><br>
-Memory-aware data analysis, graph visualization, games, and product prototypes.
-<br><br>
-<a href="https://github.com/yuansui123/AI-Data-Technician-EverMemOS">AI Data Technician</a> ·
-<a href="https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html">Memory graph</a>
-</td>
-</tr>
-</table>
-
-[Explore the full use-case gallery](docs/use-cases.md)
-
-<br>
-
 ## Stay Tuned
 
 Star the repo or join the community links above to follow new architecture methods, benchmark releases, and memory-enabled use cases.
@@ -306,45 +245,309 @@ Star the repo or join the community links above to follow new architecture metho
 
 <br>
 
-## EverMind ecosystem
+## Use Cases
 
-EverMind is an open-source ecosystem for long-term memory, self-evolving agents, and memory evaluation. EverOS is the core runtime architecture; EverMemOS is the paper and research line carrying our strongest memory-system benchmark runs; EverAlgo supplies the next-generation algorithms that make the system modular and reusable.
+Use cases show what persistent memory makes possible in real products and
+workflows. Some examples are packaged in this repository; others point to
+external demos or integrations you can study and adapt.
 
 <table>
 <tr>
-<th colspan="2">EverMind Open-Source Ecosystem</th>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
+
+#### Reunite - Find with EverOS
+
+Parents describe what they remember. Children describe what they recall. Reunite uses semantic memory to surface the connections.
+
+[Learn more](https://evermind.ai/usecase_reunite)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
+
+#### Hive Orchestrator
+
+Browser-native hive-mind for CLI coding agents - Claude Code, Codex, Gemini, and OpenCode collaborate as real PTY processes via a team protocol.
+
+[Code](https://github.com/tt-a1i/hive)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
+
+#### AI Coding Assistants with EverOS
+
+Universal long-term memory layer for AI coding assistants, powered by EverOS.
+
+[Code](https://github.com/tt-a1i/evermemos-mcp)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
+
+#### AI Data Technician
+
+An agentic AI system that learns from scientist interaction to inspect, analyze, and classify high-dimensional time series data - with persistent memory that improves across sessions.
+
+[Code](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
+
+#### Rokid AI Assistant with EverOS
+
+Connect to EverOS within Rokid Glasses enabling long-term memory for all of your smart activities.
+
+Coming soon
+
+</td>
+<td width="50%" valign="top">
+
+![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
+
+#### Creative Assistant with Memory
+
+Creative assistant with long-term memory, so your creative context stays available across sessions.
+
+Coming soon
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
+
+#### Earth Online Memory Game
+
+Earth Online is a memory-aware productivity game that turns everyday planning into a living quest log.
+
+[Code](https://github.com/xunyud/Earth-Online)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
+
+#### Multi-Agent Orchestration Platform
+
+Golutra presents a multi-agent workforce for engineering teams, extending the IDE model from a single assistant to coordinated agents.
+
+[Code](https://github.com/golutra/golutra)
+
+</td>
 </tr>
 <tr>
-<td><strong>Core memory architecture</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> / EverMemOS - the local memory operating system and research-backed runtime for agent and user memory.</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
+
+#### Your Personal Tasting Universe
+
+Record, visualize, and explore your tasting journey through an immersive 3D star map.
+
+[Code](https://github.com/Yangtze-Seventh/taste-verse)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
+
+#### EverOS Open Her
+
+Build AI that feels. Open-source persona engine - personality emerges from neural drives, not prompts. Inspired by Her.
+
+[Code](https://github.com/kellyvv/OpenHer)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
+
+#### Browser Agent for Personal Memory
+
+Ruminer brings persistent memory to a browser agent so it can carry personal context across web tasks.
+
+[Plugin](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
+
+#### EverMem Sync with EverOS
+
+One command to connect any AI coding CLI to EverMemOS long-term memory.
+
+[Code](https://github.com/nanxingw/EverMem)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
+
+#### MCO - Orchestrate AI Coding Agents
+
+MCO equips your primary agent with an agent team that can work together to solve complex tasks.
+
+[Code](https://github.com/mco-org/mco)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
+
+#### Study Buddy with Self-Evolving Memory
+
+Study proactively with an agent that has self-evolving memory.
+
+[Code](https://github.com/onenewborn/StudyBuddy-public)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
+
+#### Alzheimer's Memory Assistant
+
+Empowering individuals with advanced memory support and daily assistance.
+
+[Code](https://github.com/TonyLiangDesign/MemoCare)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
+
+#### Memory-Driven Multi-Agent NPC Experience
+
+An iOS sci-fi mystery game where players explore and uncover the truth.
+
+[Code](https://github.com/AlexL1024/NeuralConnect)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
+
+#### Mobi Companion
+
+An iOS app where users create, nurture, and live with a personalized AI companion called Mobi.
+
+[Code](https://github.com/elontusk5219-prog/Mobi)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
+
+#### AI Wearable with Memory
+
+A context-native AI wearable that listens to everyday life and converts conversations into memory.
+
+[Code](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
+
+</td>
 </tr>
 <tr>
-<td><strong>Algorithm engine</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](docs/migration-to-1.0.0.md)
+
+#### Legacy OpenClaw Agent Memory
+
+Archived pre-1.0.0 plugin reference. New integrations should use the EverOS 1.0.0 API.
+
+[Learn more](docs/migration-to-1.0.0.md)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
+
+#### Live2D Character with Memory
+
+Add long-term memory to a real-time Live2D character, powered by [TEN Framework](https://github.com/TEN-framework/ten-framework).
+
+[Code](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
+
+</td>
 </tr>
 <tr>
-<td><strong>Alternative architecture</strong></td>
-<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with its own benchmark-backed topic -> episode -> fact retrieval method.</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
+
+#### Computer-Use with Memory
+
+Run screenshot-based analysis with computer-use and store the results in memory.
+
+[Live Demo](https://screenshot-analysis-vercel.vercel.app/)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](use-cases/game-of-throne-demo)
+
+#### Game of Thrones Memories
+
+A demonstration of AI memory infrastructure through an interactive Q&A experience with *A Game of Thrones*.
+
+[Code](use-cases/game-of-throne-demo)
+
+</td>
 </tr>
 <tr>
-<td><strong>Benchmarks</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
-</tr>
-<tr>
-<td><strong>Long-context research</strong></td>
-<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
-</tr>
-<tr>
-<td><strong>Personal memory layer</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
-</tr>
-<tr>
-<td><strong>Developer integrations</strong></td>
-<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](use-cases/claude-code-plugin)
+
+#### Claude Code Plugin
+
+Persistent memory for Claude Code. Automatically saves and recalls context from past coding sessions.
+
+[Code](use-cases/claude-code-plugin)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
+
+#### Memory Graph Visualization
+
+Explore stored entities and relationships in a graph interface. Frontend demo; backend integration is in progress.
+
+[Live Demo](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
+
+</td>
 </tr>
 </table>
-
-Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
 
 <br>
 <div align="right">
@@ -352,6 +555,32 @@ Together, these repositories form EverMind's research-to-runtime stack: new memo
 [![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
 
 </div>
+
+## Related EverMind repositories
+
+<table>
+<tr>
+<th colspan="2">EverMind Open Source</th>
+</tr>
+<tr>
+<td><strong>Core</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> · <a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a></td>
+</tr>
+<tr>
+<td><strong>Memory methods</strong></td>
+<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> · <a href="https://github.com/EverMind-AI/MSA">MSA</a></td>
+</tr>
+<tr>
+<td><strong>Benchmarks</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a></td>
+</tr>
+<tr>
+<td><strong>Integrations</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> · <a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a></td>
+</tr>
+</table>
+
+<br>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 <br>
 
+- [EverOS 1.0 highlights](#everos-10-highlights)
 - [What is EverOS](#what-is-everos)
 - [Quick start](#quick-start)
 - [Architecture at a glance](#architecture-at-a-glance)
@@ -28,9 +29,9 @@
 - [Features](#features)
 - [Project structure](#project-structure)
 - [Documentation](#documentation)
-- [Stay Tuned](#stay-tuned)
 - [Use Cases](#use-cases)
-- [Related EverMind repositories](#related-evermind-repositories)
+- [Stay Tuned](#stay-tuned)
+- [EverMind ecosystems](#evermind-ecosystems)
 - [Contributing](#contributing)
 
 <br>
@@ -38,15 +39,78 @@
 </details>
 
 
-> [!NOTE]
+## EverOS 1.0 highlights
+
+> [!IMPORTANT]
 >
-> **EverOS 1.0.0 is here.** The refactor is Markdown-first, lightweight
-> enough to run locally with Python, and built around scoped user and
-> agent memory. It supports local SQLite state, LanceDB hybrid retrieval,
-> multimodal ingestion, configurable online/offline memory strategies,
-> and modular algorithms through [EverAlgo](https://github.com/EverMind-AI/EverAlgo).
+> **EverOS 1.0 is a major release for self-evolving memory.** It brings a
+> local-first runtime, Markdown as the source of truth, hybrid retrieval,
+> multimodal ingestion, user and agent memory scopes, and modular algorithms
+> through [EverAlgo](https://github.com/EverMind-AI/EverAlgo).
+>
+> **Watch this repository** for the next wave of memory-system work, including
+> Wiki-style knowledge layers and Dreaming for deeper offline evolution.
+
+<table>
+<tr>
+<td width="33%" valign="top">
+<strong>Markdown-first memory</strong><br>
+Memory is persisted as plain Markdown: visible, auditable, hand-editable,
+Git-friendly, and owned by the user.
+</td>
+<td width="33%" valign="top">
+<strong>Lightweight local stack</strong><br>
+Install with Python. SQLite tracks runtime state; LanceDB powers vector,
+BM25, and scalar-filter retrieval locally.
+</td>
+<td width="33%" valign="top">
+<strong>Layered memory model</strong><br>
+User memory and agent memory are first-class today. Wiki-style knowledge
+is the next layer in the roadmap.
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+<strong>Self-evolving agents</strong><br>
+Agent memory can extract reusable cases and skills from repeated
+experience, so workflows become smarter over time.
+</td>
+<td width="33%" valign="top">
+<strong>Multimodal ingestion</strong><br>
+Text, image, audio, documents, PDF, HTML, and email can be parsed into
+memory through the optional multimodal pipeline.
+</td>
+<td width="33%" valign="top">
+<strong>Online and offline strategy control</strong><br>
+Online extraction and offline evolution stay separate, with configurable
+prompts and models at each step. Dreaming is coming next.
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+<strong>Orthogonal memory scope</strong><br>
+Owner, memory type, and scope are independent: search by user, agent,
+app, project, session, and structured filters.
+</td>
+<td width="33%" valign="top">
+<strong>Progressive disclosure</strong><br>
+Readable memory surfaces stay simple while deeper facts, cases, and
+skills remain available.
+</td>
+<td width="33%" valign="top">
+<strong>Modular by design</strong><br>
+EverAlgo owns algorithms; EverOS owns runtime, persistence, online flows,
+and offline evolution.
+</td>
+</tr>
+</table>
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 
 ## What is EverOS
@@ -63,6 +127,11 @@ The system is built around three boundaries:
 3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## Quick start
 
@@ -144,6 +213,11 @@ make test
 ```
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## Architecture at a glance
 
@@ -165,6 +239,11 @@ make test
 DDD 5 layers, single-direction dependency. See [docs/architecture.md](docs/architecture.md).
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## Storage layout
 
@@ -194,6 +273,11 @@ is the user-facing memory surface, while extracted derivatives sit
 quietly alongside.
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## Features
 
@@ -205,6 +289,11 @@ quietly alongside.
 - **Multi-modal**: text + small image / audio inline; large media via S3/OSS reference
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## Project structure
 
@@ -223,6 +312,11 @@ everos/                        # repo root
 └── .claude/                   # team-shared rules + skills (auto-loaded by Claude Code)
 ```
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## Documentation
 
@@ -236,14 +330,12 @@ everos/                        # repo root
 - [.claude/rules/](.claude/rules/) — Detailed coding conventions (auto-loaded by Claude Code)
 
 <br>
+<div align="right">
 
-## Stay Tuned
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
 
-Star the repo or join the community links above to follow new architecture methods, benchmark releases, and memory-enabled use cases.
+</div>
 
-![star us gif](https://github.com/user-attachments/assets/0c512570-945a-483a-9f47-8e067bd34484)
-
-<br>
 
 ## Use Cases
 
@@ -328,6 +420,12 @@ Coming soon
 </tr>
 
 <tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
 <td width="50%" valign="top">
 
 [![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
@@ -398,6 +496,12 @@ One command to connect any AI coding CLI to EverMemOS long-term memory.
 
 [Code](https://github.com/nanxingw/EverMem)
 
+</td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
 </td>
 </tr>
 
@@ -473,6 +577,12 @@ A context-native AI wearable that listens to everyday life and converts conversa
 
 [Code](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
 
+</td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
 </td>
 </tr>
 <tr>
@@ -556,29 +666,65 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 
 </div>
 
-## Related EverMind repositories
+## Stay Tuned
+
+Star the repo or join the community links above to follow new architecture methods, benchmark releases, memory-enabled use cases, Wiki-style memory, and Dreaming updates.
+
+![star us gif](https://github.com/user-attachments/assets/0c512570-945a-483a-9f47-8e067bd34484)
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## EverMind ecosystems
+
+EverMind is an open-source ecosystem for long-term memory, self-evolving agents, and memory evaluation. EverOS is the core runtime architecture; EverMemOS is the paper and research line carrying our strongest memory-system benchmark runs; EverAlgo supplies the next-generation algorithms that make the system modular and reusable.
 
 <table>
 <tr>
-<th colspan="2">EverMind Open Source</th>
+<th colspan="2">EverMind Open-Source Ecosystem</th>
 </tr>
 <tr>
-<td><strong>Core</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> · <a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a></td>
+<td><strong>Core memory architecture</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> / EverMemOS - the local memory operating system and research-backed runtime for agent and user memory.</td>
 </tr>
 <tr>
-<td><strong>Memory methods</strong></td>
-<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> · <a href="https://github.com/EverMind-AI/MSA">MSA</a></td>
+<td><strong>Algorithm engine</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
+</tr>
+<tr>
+<td><strong>Alternative architecture</strong></td>
+<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - hypergraph memory for long-term conversations, with its own benchmark-backed topic -> episode -> fact retrieval method.</td>
 </tr>
 <tr>
 <td><strong>Benchmarks</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a></td>
+<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - evaluation suites for conversational memory and agent self-evolution.</td>
 </tr>
 <tr>
-<td><strong>Integrations</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> · <a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a></td>
+<td><strong>Long-context research</strong></td>
+<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
+</tr>
+<tr>
+<td><strong>Personal memory layer</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
+</tr>
+<tr>
+<td><strong>Developer integrations</strong></td>
+<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - plugins, skills, and migration tooling for AI coding agents.</td>
 </tr>
 </table>
+
+Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 <br>
 
+- [EverOS 1.0.0 highlights](#everos-100-highlights)
 - [What is EverOS](#what-is-everos)
 - [Architecture at a glance](#architecture-at-a-glance)
 - [Quick start](#quick-start)
@@ -36,6 +37,70 @@
 <br>
 
 </details>
+
+
+## EverOS 1.0.0 highlights
+
+EverOS 1.0.0 is the refactored local-first memory runtime for auditable
+user memory, self-evolving agent memory, and modular memory algorithms.
+The core idea is simple: memory should be readable, recoverable, and
+useful without handing ownership to an opaque hosted system.
+
+<table>
+<tr>
+<td width="33%" valign="top">
+<strong>Markdown-first memory</strong><br>
+Memory is persisted as plain Markdown: visible, auditable, hand-editable,
+Git-friendly, and owned by the user.
+</td>
+<td width="33%" valign="top">
+<strong>Lightweight local stack</strong><br>
+Install with Python. SQLite tracks runtime state; LanceDB powers vector,
+BM25, and scalar-filter retrieval locally.
+</td>
+<td width="33%" valign="top">
+<strong>Layered memory model</strong><br>
+User memory and agent memory are first-class today. Wiki-style world
+knowledge is the next layer in the roadmap.
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+<strong>Self-evolving agents</strong><br>
+Agent memory can extract reusable cases and skills from repeated
+experience, so workflows become smarter over time.
+</td>
+<td width="33%" valign="top">
+<strong>Multimodal ingestion</strong><br>
+Text, image, audio, documents, PDF, HTML, and email can be parsed into
+memory through the optional multimodal pipeline.
+</td>
+<td width="33%" valign="top">
+<strong>Online and offline strategy control</strong><br>
+Online extraction and offline evolution stay separate, with configurable
+prompts and models at each step. Reflection ships next.
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+<strong>Orthogonal memory scope</strong><br>
+Owner, memory type, and scope are independent: search by user, agent,
+app, project, session, and structured filters.
+</td>
+<td width="33%" valign="top">
+<strong>Progressive disclosure</strong><br>
+Readable memory surfaces stay simple while deeper facts, cases, and
+skills remain available. LLM Wiki will extend this to domain/topic/content.
+</td>
+<td width="33%" valign="top">
+<strong>Modular by design</strong><br>
+EverAlgo owns algorithms; EverOS owns runtime, persistence, online flows,
+and offline evolution.
+</td>
+</tr>
+</table>
+
+<br>
 
 
 ## What is EverOS

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
 
 <br>
 
-- [EverOS 1.0.0 highlights](#everos-100-highlights)
+- [EverOS 1.0.0 in 30 seconds](#everos-100-in-30-seconds)
 - [What is EverOS](#what-is-everos)
-- [Architecture at a glance](#architecture-at-a-glance)
 - [Quick start](#quick-start)
+- [Architecture at a glance](#architecture-at-a-glance)
 - [Storage layout](#storage-layout)
 - [Features](#features)
 - [Project structure](#project-structure)
@@ -39,63 +39,34 @@
 </details>
 
 
-## EverOS 1.0.0 highlights
+## EverOS 1.0.0 in 30 seconds
 
-EverOS 1.0.0 is the refactored local-first memory runtime for auditable
-user memory, self-evolving agent memory, and modular memory algorithms.
-The core idea is simple: memory should be readable, recoverable, and
-useful without handing ownership to an opaque hosted system.
+EverOS gives AI agents a local memory system that developers can inspect,
+edit, rebuild, and extend.
 
 <table>
 <tr>
-<td width="33%" valign="top">
-<strong>Markdown-first memory</strong><br>
-Memory is persisted as plain Markdown: visible, auditable, hand-editable,
-Git-friendly, and owned by the user.
+<td width="50%" valign="top">
+<strong>Memory you can read</strong><br>
+Plain Markdown is the source of truth. SQLite and LanceDB are local,
+rebuildable indexes.
 </td>
-<td width="33%" valign="top">
-<strong>Lightweight local stack</strong><br>
-Install with Python. SQLite tracks runtime state; LanceDB powers vector,
-BM25, and scalar-filter retrieval locally.
-</td>
-<td width="33%" valign="top">
-<strong>Layered memory model</strong><br>
-User memory and agent memory are first-class today. Wiki-style world
-knowledge is the next layer in the roadmap.
+<td width="50%" valign="top">
+<strong>Easy to run locally</strong><br>
+Install with Python. No Docker, MongoDB, Elasticsearch, Redis, Kafka, or
+hosted database is required.
 </td>
 </tr>
 <tr>
-<td width="33%" valign="top">
-<strong>Self-evolving agents</strong><br>
-Agent memory can extract reusable cases and skills from repeated
-experience, so workflows become smarter over time.
+<td width="50%" valign="top">
+<strong>User and agent memory</strong><br>
+Store profiles, episodes, task cases, and skills with scoped search by
+user, agent, app, project, and session.
 </td>
-<td width="33%" valign="top">
-<strong>Multimodal ingestion</strong><br>
-Text, image, audio, documents, PDF, HTML, and email can be parsed into
-memory through the optional multimodal pipeline.
-</td>
-<td width="33%" valign="top">
-<strong>Online and offline strategy control</strong><br>
-Online extraction and offline evolution stay separate, with configurable
-prompts and models at each step. Reflection ships next.
-</td>
-</tr>
-<tr>
-<td width="33%" valign="top">
-<strong>Orthogonal memory scope</strong><br>
-Owner, memory type, and scope are independent: search by user, agent,
-app, project, session, and structured filters.
-</td>
-<td width="33%" valign="top">
-<strong>Progressive disclosure</strong><br>
-Readable memory surfaces stay simple while deeper facts, cases, and
-skills remain available. LLM Wiki will extend this to domain/topic/content.
-</td>
-<td width="33%" valign="top">
-<strong>Modular by design</strong><br>
-EverAlgo owns algorithms; EverOS owns runtime, persistence, online flows,
-and offline evolution.
+<td width="50%" valign="top">
+<strong>Evolving, multimodal memory</strong><br>
+Ingest text, image, audio, docs, PDF, HTML, and email. Online extraction
+and offline evolution are configurable; Reflection and LLM Wiki are next.
 </td>
 </tr>
 </table>
@@ -105,46 +76,43 @@ and offline evolution.
 
 ## What is EverOS
 
-EverOS is an open-source Python framework that turns conversations, agent trajectories, and files into **structured, retrievable, evolving long-term memory** for AI agents and user chats. Designed for **lightweight local deployments** (small teams, individual developers), with three core principles:
+EverOS is an open-source Python framework for long-term memory in AI
+agents and user chats. It turns conversations, agent trajectories, and
+files into structured memory, then keeps local retrieval indexes in sync
+so the memory can be searched and reused.
 
-1. **Markdown as Source of Truth** — All memory persists as plain `.md` files. Open, edit, grep, version with Git, view in Obsidian. No black-box database lock-in.
-2. **Lightweight three-piece storage** — `Markdown` files (truth) + `SQLite` (state/queue) + `LanceDB` (vector + BM25 + scalar). No MongoDB / Elasticsearch / Milvus / Redis / Kafka required.
-3. **[EverAlgo](https://github.com/EverMind-AI/EverAlgo) as pure algorithm library** — Memory extraction algorithms are decoupled into a separate library; this project orchestrates and persists.
+The system is built around three boundaries:
 
-<br>
-
-## Architecture at a glance
-
-```
-┌───────────────────────────────────────────────┐
-│  entrypoints/  (CLI + HTTP API)                │  presentation
-├───────────────────────────────────────────────┤
-│  service/      (use cases: memorize/retrieve)  │  application
-├───────────────────────────────────────────────┤
-│  memory/       (extract + search + cascade)    │  domain
-├───────────────────────────────────────────────┤
-│  infra/        (markdown / sqlite / lancedb)   │  infrastructure
-└───────────────────────────────────────────────┘
-        ↑                    ↑
-   component/            core/
-   (LLM/Embedding)       (observability/lifespan)
-```
-
-DDD 5 layers, single-direction dependency. See [docs/architecture.md](docs/architecture.md).
+1. **Memory content stays readable** - Markdown is the durable source of truth.
+2. **Runtime state stays local** - SQLite tracks state and LanceDB handles vector, BM25, and scalar-filter search.
+3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
 
 <br>
 
 ## Quick start
 
-### Install as a package
+### 1. Install EverOS
 
 ```bash
-uv pip install everos               # or: pip install everos
+uv pip install everos
+# or: pip install everos
+```
 
-# Generate a starter .env (OpenRouter + DeepInfra defaults; bundled inside the wheel)
-everos init                          # writes ./.env (use --xdg for ~/.config/everos/.env)
-# Edit .env and fill the API key fields (see comments inside).
+### 2. Initialize configuration
 
+Generate a starter `.env` file, then fill the API key fields shown in
+the generated comments.
+
+```bash
+everos init
+```
+
+`everos init` writes `./.env` by default. Use `everos init --xdg` to
+write `${XDG_CONFIG_HOME:-~/.config}/everos/.env` instead.
+
+### 3. Start the server
+
+```bash
 everos --help
 everos server start
 ```
@@ -152,10 +120,13 @@ everos server start
 `everos server start` searches for `.env` in this order: `--env-file <path>` →
 `./.env` (cwd) → `${XDG_CONFIG_HOME:-~/.config}/everos/.env` → `~/.everos/.env`.
 The endpoint stack is OpenAI-protocol compatible (OpenAI / OpenRouter / vLLM /
-Ollama / DeepInfra …) — override `*__BASE_URL` in the generated `.env` to point
+Ollama / DeepInfra) - override `*__BASE_URL` in the generated `.env` to point
 at any of them.
 
-#### Multi-modal (optional)
+For a step-by-step walkthrough (add a conversation, flush, search, then
+read the markdown), see [QUICKSTART.md](QUICKSTART.md).
+
+### Optional: ingest multimodal files
 
 To ingest non-text content (image / pdf / audio / office documents)
 through `/api/v1/memory/add` `content` items, install the optional
@@ -184,22 +155,39 @@ brew install --cask libreoffice              # macOS
 sudo apt-get install -y libreoffice          # Debian / Ubuntu
 ```
 
-For a step-by-step walkthrough (add a conversation → flush → search →
-read the markdown), see [QUICKSTART.md](QUICKSTART.md).
-
-
-### Develop locally
+### For contributors
 
 ```bash
 git clone https://github.com/EverMind-AI/EverOS.git
 cd EverOS
 uv sync                              # creates ./.venv and installs deps
-source .venv/bin/activate            # — or skip activation and prefix every command with `uv run`
+source .venv/bin/activate            # or prefix commands with `uv run`
 everos init                          # fill the four API key slots in .env (two distinct keys)
 
 everos --help
 make test
 ```
+
+<br>
+
+## Architecture at a glance
+
+```
+┌───────────────────────────────────────────────┐
+│  entrypoints/  (CLI + HTTP API)                │  presentation
+├───────────────────────────────────────────────┤
+│  service/      (use cases: memorize/retrieve)  │  application
+├───────────────────────────────────────────────┤
+│  memory/       (extract + search + cascade)    │  domain
+├───────────────────────────────────────────────┤
+│  infra/        (markdown / sqlite / lancedb)   │  infrastructure
+└───────────────────────────────────────────────┘
+        ↑                    ↑
+   component/            core/
+   (LLM/Embedding)       (observability/lifespan)
+```
+
+DDD 5 layers, single-direction dependency. See [docs/architecture.md](docs/architecture.md).
 
 <br>
 
@@ -266,6 +254,7 @@ everos/                        # repo root
 - [docs/overview.md](docs/overview.md) — Project overview & vision
 - [docs/architecture.md](docs/architecture.md) — DDD layered architecture & dependency rules
 - [docs/engineering.md](docs/engineering.md) — Engineering & dev-efficiency infrastructure (CI / tooling / Claude Code)
+- [docs/use-cases.md](docs/use-cases.md) — Full use-case gallery and integration examples
 - [docs/migration-to-1.0.0.md](docs/migration-to-1.0.0.md) — Legacy API and infrastructure migration notes
 - [CHANGELOG.md](CHANGELOG.md) — Release notes
 - [CONTRIBUTING.md](CONTRIBUTING.md) — How to contribute
@@ -275,312 +264,39 @@ everos/                        # repo root
 
 ## Use Cases
 
-Use cases show what persistent memory makes possible in real products and workflows. Some examples are packaged in this repository; others point to external demos or integrations you can study and adapt.
+EverOS is already being used across AI coding, personal memory, creative
+assistants, games, browser agents, and research workflows. The README keeps
+the path short; the full showcase lives in [docs/use-cases.md](docs/use-cases.md).
 
 <table>
 <tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
-
-#### Reunite - Find with EverOS
-
-Parents describe what they remember. Children describe what they recall. Reunite uses semantic memory to surface the connections.
-
-[Learn more](https://evermind.ai/usecase_reunite)
-
+<td width="33%" valign="top">
+<strong>AI coding memory</strong><br>
+Persistent context for coding assistants and multi-agent engineering workflows.
+<br><br>
+<a href="https://github.com/tt-a1i/evermemos-mcp">Coding assistant memory</a> ·
+<a href="https://github.com/tt-a1i/hive">Hive</a>
 </td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
-
-#### Hive Orchestrator
-
-Browser-native hive-mind for CLI coding agents — Claude Code, Codex, Gemini, and OpenCode collaborate as real PTY processes via a team protocol.
-
-[Code](https://github.com/tt-a1i/hive)
-
+<td width="33%" valign="top">
+<strong>Personal memory products</strong><br>
+Memory for companions, browser agents, wearables, education, and daily life.
+<br><br>
+<a href="https://evermind.ai/usecase_reunite">Reunite</a> ·
+<a href="https://github.com/TonyLiangDesign/MemoCare">MemoCare</a>
 </td>
-</tr>
-
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
-
-#### AI Coding Assistants with EverOS
-
-Universal long-term memory layer for AI coding assistants, powered by EverOS.
-
-[Code](https://github.com/tt-a1i/evermemos-mcp)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
-
-#### AI Data Techician
-
-An agentic AI system that learns from scientist interaction to inspect, analyze, and classify high-dimensional time series data — with persistent memory that improves across sessions.
-
-[Code](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
-
-</td>
-</tr>
-
-<tr>
-<td width="50%" valign="top">
-
-![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
-
-#### Rokid AI Assistant with EverOS
-
-Connect to EverOS within Rokid Glasses enabling long-term memory for all of your smart activities.
-
-Coming soon
-
-</td>
-<td width="50%" valign="top">
-
-![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
-
-#### Creative Assistant with Memory
-
-Creative assistant with long-term memory, never forget your crativites anymore.
-
-Coming soon
-
-</td>
-</tr>
-
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
-
-#### Earth Online Memory Game
-
-Earth Online is a memory-aware productivity game that turns everyday planning into a living quest log.
-
-[Code](https://github.com/xunyud/Earth-Online)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
-
-#### Multi-Agent Orchestration Platform
-
-Golutra presents a multi-agent workforce for engineering teams, extending the IDE model from a single assistant to coordinated agents.
-
-[Code](https://github.com/golutra/golutra)
-
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
-
-#### Your Personal Tasting Universe
-
-Record, visualize, and explore your tasting journey through an immersive 3D star map.
-
-[Code](https://github.com/Yangtze-Seventh/taste-verse)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
-
-#### EverOS Open Her
-
-Build AI that feels. Open-source persona engine — personality emerges from neural drives, not prompts. Inspired by Her.
-
-[Code](https://github.com/kellyvv/OpenHer)
-
-</td>
-</tr>
-
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
-
-#### Browser Agent for Personal Memory
-
-Ruminer brings persistent memory to a browser agent so it can carry personal context across web tasks.
-
-[Plugin](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
-
-#### EverMem Sync with EverOS
-
-One command to connect any AI coding CLI to EverMemOS long-term memory.
-
-[Code](https://github.com/nanxingw/EverMem)
-
-</td>
-</tr>
-
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
-
-#### MCO - Orchestrate AI Coding Agents
-
-MCO equips your primary agent with an agent team that can work together to solve complex tasks.
-
-[Code](https://github.com/mco-org/mco)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
-
-#### Study Buddy with Self-Evolving Memory
-
-Study proactively with an agent that has self-evolving memory.
-
-[Code](https://github.com/onenewborn/StudyBuddy-public)
-
-</td>
-</tr>
-
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
-
-#### Alzheimer’s Memory Assistant
-
-Empowering individuals with advanced memory support and daily assistance.
-
-[Code](https://github.com/TonyLiangDesign/MemoCare)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
-
-#### Memory-Driven Multi-Agent NPC Experience
-
-An iOS sci-fi mystery game where players explore and uncover the truth.
-
-[Code](https://github.com/AlexL1024/NeuralConnect)
-
-</td>
-</tr>
-
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
-
-#### Mobi Companion
-
-An iOS app where users create, nurture, and live with a personalized AI companion called Mobi.
-
-[Code](https://github.com/elontusk5219-prog/Mobi)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
-
-#### AI Wearable with Memory
-
-A context-native AI wearable that listens to everyday life and converts conversations into memory.
-
-[Code](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
-
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](docs/migration-to-1.0.0.md)
-
-#### Legacy OpenClaw Agent Memory
-
-Archived pre-1.0.0 plugin reference. New integrations should use the EverOS 1.0.0 API.
-
-[Learn more](docs/migration-to-1.0.0.md)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
-
-#### Live2D Character with Memory
-
-Add long-term memory to a real-time Live2D character, powered by [TEN Framework](https://github.com/TEN-framework/ten-framework).
-
-[Code](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
-
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
-
-#### Computer-Use with Memory
-
-Run screenshot-based analysis with computer-use and store the results in memory.
-
-[Live Demo](https://screenshot-analysis-vercel.vercel.app/)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](use-cases/game-of-throne-demo)
-
-#### Game of Thrones Memories
-
-A demonstration of AI memory infrastructure through an interactive Q&A experience with *A Game of Thrones*.
-
-[Code](use-cases/game-of-throne-demo)
-
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](use-cases/claude-code-plugin)
-
-#### Claude Code Plugin
-
-Persistent memory for Claude Code. Automatically saves and recalls context from past coding sessions.
-
-[Code](use-cases/claude-code-plugin)
-
-</td>
-<td width="50%" valign="top">
-
-[![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
-
-#### Memory Graph Visualization
-
-Explore stored entities and relationships in a graph interface. Frontend demo; backend integration is in progress.
-
-[Live Demo](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
-
+<td width="33%" valign="top">
+<strong>Research and demos</strong><br>
+Memory-aware data analysis, graph visualization, games, and product prototypes.
+<br><br>
+<a href="https://github.com/yuansui123/AI-Data-Technician-EverMemOS">AI Data Technician</a> ·
+<a href="https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html">Memory graph</a>
 </td>
 </tr>
 </table>
 
+[Explore the full use-case gallery](docs/use-cases.md)
+
 <br>
-<div align="right">
-
-[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
-
-</div>
 
 ## Stay Tuned
 

--- a/README.md
+++ b/README.md
@@ -53,54 +53,27 @@
 
 <table>
 <tr>
-<td width="33%" valign="top">
-<strong>Markdown-First Memory</strong><br>
-Memory is persisted as plain Markdown: visible, auditable, hand-editable,
-Git-friendly, and owned by the user.
+<td width="50%" valign="top">
+<strong>Self-Evolving Long-Term Memory</strong><br>
+Agents can reuse past cases and skills, improve from repeated workflows,
+and become more proactive over time.
 </td>
-<td width="33%" valign="top">
-<strong>Lightweight Local Stack</strong><br>
-Install with Python. SQLite tracks runtime state; LanceDB powers vector,
-BM25, and scalar-filter retrieval locally.
-</td>
-<td width="33%" valign="top">
-<strong>Layered Memory Model</strong><br>
-User memory and agent memory are first-class today. Wiki-style knowledge
-is the next layer in the roadmap.
+<td width="50%" valign="top">
+<strong>Cross-Agent + Cross-Platform</strong><br>
+One portable memory layer follows Claude Code, Codex, OpenClaw, Hermes,
+and the next agents makers build with.
 </td>
 </tr>
 <tr>
-<td width="33%" valign="top">
-<strong>Self-Evolving Agents</strong><br>
-Agent memory can extract reusable cases and skills from repeated
-experience, so workflows become smarter over time.
+<td width="50%" valign="top">
+<strong>Markdown-First, User-Owned</strong><br>
+Memory is stored as readable Markdown: visible, auditable, hand-editable,
+Git-friendly, and easy to bring into your own workflow.
 </td>
-<td width="33%" valign="top">
-<strong>Multimodal Ingestion</strong><br>
-Text, image, audio, documents, PDF, HTML, and email can be parsed into
-memory through the optional multimodal pipeline.
-</td>
-<td width="33%" valign="top">
-<strong>Online And Offline Strategy Control</strong><br>
-Online extraction and offline evolution stay separate, with configurable
-prompts and models at each step. Dreaming is coming next.
-</td>
-</tr>
-<tr>
-<td width="33%" valign="top">
-<strong>Orthogonal Memory Scope</strong><br>
-Owner, memory type, and scope are independent: search by user, agent,
-app, project, session, and structured filters.
-</td>
-<td width="33%" valign="top">
-<strong>Progressive Disclosure</strong><br>
-Readable memory surfaces stay simple while deeper facts, cases, and
-skills remain available.
-</td>
-<td width="33%" valign="top">
-<strong>Modular By Design</strong><br>
-EverAlgo owns algorithms; EverOS owns runtime, persistence, online flows,
-and offline evolution.
+<td width="50%" valign="top">
+<strong>Local Runtime, Modular Algorithms</strong><br>
+SQLite and LanceDB keep retrieval local while EverAlgo supplies reusable
+memory algorithms for online and offline evolution.
 </td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ and offline evolution.
 
 ## What Is EverOS
 
-EverOS is an open-source Python framework for long-term memory in AI
-agents and user chats. It turns conversations, agent trajectories, and
-files into structured memory, then keeps local retrieval indexes in sync
-so the memory can be searched and reused.
+EverOS is an open-source Python framework for self-evolving memory across
+agents and platforms. It turns conversations, agent trajectories, and
+files into structured long-term memory, then keeps local retrieval indexes
+in sync so the memory can be searched and reused.
 
 The system is built around three boundaries:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![EverOS banner](https://github.com/EverMind-AI/EverOS/releases/download/v1.0.0/everos-readme-banner.jpg)
+![EverOS banner](https://github.com/user-attachments/assets/fadd7680-544f-40bc-ba8a-34ad4723fd19)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 <br>
 
-- [EverOS 1.0.0 Highlights](#everos-100-highlights)
 - [What Is EverOS](#what-is-everos)
+- [EverOS 1.0.0 Highlights](#everos-100-highlights)
 - [Quick Start](#quick-start)
 - [Architecture At A Glance](#architecture-at-a-glance)
 - [Storage Layout](#storage-layout)
@@ -37,6 +37,33 @@
 <br>
 
 </details>
+
+
+## What Is EverOS
+
+EverOS is an open-source Python framework for self-evolving long-term
+memory across agents and platforms. It gives makers one portable memory
+layer for every agent they use - Claude Code, Codex, OpenClaw, Hermes,
+and more - so context, decisions, files, and trajectories can follow the
+work instead of staying trapped in one tool.
+
+EverOS stores conversations, agent trajectories, and files as readable
+Markdown, then syncs local SQLite and LanceDB indexes for fast retrieval.
+Agents can reuse past cases and skills, improve from repeated workflows,
+and become more proactive over time.
+
+The system is built around three boundaries:
+
+1. **Memory content stays readable** - Markdown is the durable source of truth.
+2. **Runtime state stays local** - SQLite tracks state and LanceDB handles vector, BM25, and scalar-filter search.
+3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 
 ## EverOS 1.0.0 Highlights
@@ -112,26 +139,6 @@ and offline evolution.
 
 </div>
 
-
-## What Is EverOS
-
-EverOS is an open-source Python framework for self-evolving memory across
-agents and platforms. It turns conversations, agent trajectories, and
-files into structured long-term memory, then keeps local retrieval indexes
-in sync so the memory can be searched and reused.
-
-The system is built around three boundaries:
-
-1. **Memory content stays readable** - Markdown is the durable source of truth.
-2. **Runtime state stays local** - SQLite tracks state and LanceDB handles vector, BM25, and scalar-filter search.
-3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
-
-<br>
-<div align="right">
-
-[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
-
-</div>
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,191 @@
+<div align="center" id="readme-top">
+
+![EverOS banner](https://github.com/EverMind-AI/EverOS/releases/download/v1.0.0/everos-readme-banner.jpg)
+
+<p align="center">
+  <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/🤗_HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
+  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
+</p>
+
+[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [Blog](https://evermind.ai/blogs) · [English](README.md)
+
+</div>
+
+<br>
+
+<details>
+  <summary><kbd>目录</kbd></summary>
+
+<br>
+
+- [EverOS 1.0.0 亮点](#everos-100-亮点)
+- [什么是 EverOS](#什么是-everos)
+- [快速开始](#快速开始)
+- [架构概览](#架构概览)
+- [功能](#功能)
+- [文档](#文档)
+- [EverMind 生态](#evermind-生态)
+- [Star History](#star-history)
+
+<br>
+
+</details>
+
+## EverOS 1.0.0 亮点
+
+> [!IMPORTANT]
+>
+> **EverOS 1.0.0 是面向自进化记忆的一次重要发布。** 它带来了
+> local-first 运行时、Markdown 作为记忆源数据、混合检索、多模态
+> 摄取、用户/Agent 记忆作用域，以及由
+> [EverAlgo](https://github.com/EverMind-AI/EverAlgo) 支撑的模块化算法。
+>
+> **欢迎 Watch 这个仓库。** 后续我们会持续推进 Wiki 式知识层、
+> Dreaming 离线进化，以及更多面向 Agent 的长期记忆能力。
+
+<table>
+<tr>
+<td width="33%" valign="top">
+<strong>Markdown-First Memory</strong><br>
+记忆以 Markdown 持久化：可读、可审计、可手动编辑，也方便 Git 管理。
+</td>
+<td width="33%" valign="top">
+<strong>Lightweight Local Stack</strong><br>
+Python 即可安装。SQLite 负责运行时状态，LanceDB 负责向量、BM25 和结构化过滤检索。
+</td>
+<td width="33%" valign="top">
+<strong>Self-Evolving Agents</strong><br>
+Agent 可以从重复工作流中沉淀可复用的 cases 和 skills，并随着使用持续改进。
+</td>
+</tr>
+</table>
+
+<br>
+
+## 什么是 EverOS
+
+EverOS 是一个开源 Python 框架，用来构建**跨 Agent、跨平台的自进化长期记忆**。
+它让 maker 可以为所有常用 Agent 维护同一套可携带的记忆层，例如
+Claude Code、Codex、OpenClaw、Hermes 等，让上下文、决策、文件和
+Agent 轨迹跟着工作流走，而不是被锁在某一个工具里。
+
+EverOS 会把对话、Agent 轨迹和文件保存为可读的 Markdown，并同步本地
+SQLite 与 LanceDB 索引，方便快速检索。Agent 可以复用过去的 cases
+和 skills，从重复工作中自我改进，并逐渐变得更加主动。
+
+EverOS 的核心边界：
+
+1. **记忆内容保持可读** - Markdown 是长期记忆的 source of truth。
+2. **运行时状态保持本地** - SQLite 负责状态，LanceDB 负责向量、BM25 和结构化过滤。
+3. **算法保持模块化** - EverAlgo 负责记忆算法，EverOS 负责运行时、持久化、在线流程和离线进化。
+
+<br>
+
+## 快速开始
+
+### 1. 安装 EverOS
+
+```bash
+uv pip install everos
+# or: pip install everos
+```
+
+### 2. 初始化配置
+
+```bash
+everos init
+```
+
+`everos init` 默认写入 `./.env`。你也可以使用 `everos init --xdg`
+写入 `${XDG_CONFIG_HOME:-~/.config}/everos/.env`。
+
+### 3. 启动服务
+
+```bash
+everos --help
+everos server start
+```
+
+EverOS 的端点兼容 OpenAI protocol，可以接入 OpenAI、OpenRouter、
+vLLM、Ollama、DeepInfra 等服务。修改 `.env` 中的 `*__BASE_URL`
+即可指向对应模型服务。
+
+<br>
+
+## 架构概览
+
+```
+┌───────────────────────────────────────────────┐
+│  entrypoints/  (CLI + HTTP API)                │  presentation
+├───────────────────────────────────────────────┤
+│  service/      (use cases: memorize/retrieve)  │  application
+├───────────────────────────────────────────────┤
+│  memory/       (extract + search + cascade)    │  domain
+├───────────────────────────────────────────────┤
+│  infra/        (markdown / sqlite / lancedb)   │  infrastructure
+└───────────────────────────────────────────────┘
+        ↑                    ↑
+   component/            core/
+   (LLM/Embedding)       (observability/lifespan)
+```
+
+DDD 5 层架构，单向依赖。详见 [docs/architecture.md](docs/architecture.md)。
+
+<br>
+
+## 功能
+
+- **Hybrid Retrieval**: BM25 + vector + scalar filter，统一由 LanceDB 查询
+- **Cascade Index Sync**: 修改 `.md` 后自动 diff 并同步到 LanceDB
+- **Multi-Source Extraction**: 支持对话、Agent 轨迹、文件知识
+- **Dual-Track Memory**: 用户记忆和 Agent 记忆分层管理
+- **Multimodal Ingestion**: 支持文本、图片、音频、PDF、Office 文档等
+- **Modular Algorithms**: EverAlgo 负责可复用的算法层
+
+<br>
+
+## 文档
+
+- [QUICKSTART.md](QUICKSTART.md) - 快速上手
+- [docs/overview.md](docs/overview.md) - 项目愿景与概览
+- [docs/architecture.md](docs/architecture.md) - 架构设计
+- [docs/api.md](docs/api.md) - API 文档
+- [docs/use-cases.md](docs/use-cases.md) - 用例集合
+- [CHANGELOG.md](CHANGELOG.md) - 版本记录
+
+<br>
+
+## EverMind 生态
+
+EverMind 是面向长期记忆、自进化 Agent 和记忆评测的开源生态。
+EverOS 是核心运行时；EverAlgo 提供算法引擎；EverMemBench 和
+EvoAgentBench 提供评测基准；EverMe 和相关插件面向跨设备、跨 Agent
+的个人记忆工作流。
+
+相关仓库：
+
+- [EverOS](https://github.com/EverMind-AI/EverOS)
+- [EverAlgo](https://github.com/EverMind-AI/EverAlgo)
+- [HyperMem](https://github.com/EverMind-AI/HyperMem)
+- [EverMemBench](https://github.com/EverMind-AI/EverMemBench)
+- [EvoAgentBench](https://github.com/EverMind-AI/EvoAgentBench)
+- [EverMe](https://github.com/EverMind-AI/EverMe)
+
+<br>
+
+## Star History
+
+关注 EverOS 的社区增长，也欢迎 Star 和 Watch 这个仓库，持续跟进
+EverOS 1.0.0 之后的 Wiki 式知识层、Dreaming 离线进化和 Agent 记忆能力。
+
+[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/EverOS&type=Date)](https://www.star-history.com/#EverMind-AI/EverOS&Date)
+
+<br>
+
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,45 +53,23 @@
 
 <table>
 <tr>
-<td width="33%" valign="top">
-<strong>Markdown-First Memory</strong><br>
-记忆以普通 Markdown 持久化：可见、可审计、可手动编辑、Git 友好，并由用户自己拥有。
+<td width="50%" valign="top">
+<strong>Self-Evolving Long-Term Memory</strong><br>
+Agent 可以复用过去的 cases 和 skills，从重复工作流中自我改进，并逐渐变得更加主动。
 </td>
-<td width="33%" valign="top">
-<strong>Lightweight Local Stack</strong><br>
-用 Python 即可安装。SQLite 负责运行时状态；LanceDB 在本地提供向量、BM25 和结构化过滤检索。
-</td>
-<td width="33%" valign="top">
-<strong>Layered Memory Model</strong><br>
-用户记忆和 Agent 记忆现在是一等公民。Wiki 式知识层是路线图中的下一层。
+<td width="50%" valign="top">
+<strong>Cross-Agent + Cross-Platform</strong><br>
+一层可携带的记忆跟随 Claude Code、Codex、OpenClaw、Hermes，以及 maker 接下来构建的 Agent。
 </td>
 </tr>
 <tr>
-<td width="33%" valign="top">
-<strong>Self-Evolving Agents</strong><br>
-Agent 记忆可以从重复经验中提取可复用的 cases 和 skills，让工作流随着时间变得更聪明。
+<td width="50%" valign="top">
+<strong>Markdown-First, User-Owned</strong><br>
+记忆以可读 Markdown 存储：可见、可审计、可手动编辑、Git 友好，也方便接入自己的工作流。
 </td>
-<td width="33%" valign="top">
-<strong>Multimodal Ingestion</strong><br>
-文本、图片、音频、文档、PDF、HTML 和邮件都可以通过可选的多模态管线解析进记忆。
-</td>
-<td width="33%" valign="top">
-<strong>Online And Offline Strategy Control</strong><br>
-在线提取和离线进化保持分离，并且每一步都可以配置 prompts 和 models。Dreaming 即将到来。
-</td>
-</tr>
-<tr>
-<td width="33%" valign="top">
-<strong>Orthogonal Memory Scope</strong><br>
-Owner、memory type 和 scope 相互独立：可以按 user、agent、app、project、session 和结构化 filters 搜索。
-</td>
-<td width="33%" valign="top">
-<strong>Progressive Disclosure</strong><br>
-可读记忆界面保持简单，同时更深层的 facts、cases 和 skills 仍然可以被系统使用。
-</td>
-<td width="33%" valign="top">
-<strong>Modular By Design</strong><br>
-EverAlgo 负责算法；EverOS 负责运行时、持久化、在线流程和离线进化。
+<td width="50%" valign="top">
+<strong>Local Runtime, Modular Algorithms</strong><br>
+SQLite 和 LanceDB 让检索保持本地化；EverAlgo 提供可复用的记忆算法，支撑在线与离线进化。
 </td>
 </tr>
 </table>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,9 +9,10 @@
   <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [Blog](https://evermind.ai/blogs) · [English](README.md)
+[官网](https://evermind.ai) · [文档](https://docs.evermind.ai) · [博客](https://evermind.ai/blogs) · [English](README.md)
 
 </div>
+
 
 <br>
 
@@ -24,64 +25,109 @@
 - [什么是 EverOS](#什么是-everos)
 - [快速开始](#快速开始)
 - [架构概览](#架构概览)
+- [存储布局](#存储布局)
 - [功能](#功能)
+- [项目结构](#项目结构)
 - [文档](#文档)
+- [使用场景](#使用场景)
+- [持续关注](#持续关注)
 - [EverMind 生态](#evermind-生态)
-- [Star History](#star-history)
+- [参与贡献](#参与贡献)
 
 <br>
 
 </details>
+
 
 ## EverOS 1.0.0 亮点
 
 > [!IMPORTANT]
 >
 > **EverOS 1.0.0 是面向自进化记忆的一次重要发布。** 它带来了
-> local-first 运行时、Markdown 作为记忆源数据、混合检索、多模态
-> 摄取、用户/Agent 记忆作用域，以及由
+> local-first 运行时、Markdown 作为 source of truth、混合检索、
+> 多模态摄取、用户记忆与 Agent 记忆作用域，以及由
 > [EverAlgo](https://github.com/EverMind-AI/EverAlgo) 支撑的模块化算法。
 >
-> **欢迎 Watch 这个仓库。** 后续我们会持续推进 Wiki 式知识层、
-> Dreaming 离线进化，以及更多面向 Agent 的长期记忆能力。
+> **欢迎 Watch 这个仓库。** 下一阶段我们会继续推进记忆系统方法，
+> 包括 Wiki 式知识层和用于更深层离线进化的 Dreaming。
 
 <table>
 <tr>
 <td width="33%" valign="top">
 <strong>Markdown-First Memory</strong><br>
-记忆以 Markdown 持久化：可读、可审计、可手动编辑，也方便 Git 管理。
+记忆以普通 Markdown 持久化：可见、可审计、可手动编辑、Git 友好，并由用户自己拥有。
 </td>
 <td width="33%" valign="top">
 <strong>Lightweight Local Stack</strong><br>
-Python 即可安装。SQLite 负责运行时状态，LanceDB 负责向量、BM25 和结构化过滤检索。
+用 Python 即可安装。SQLite 负责运行时状态；LanceDB 在本地提供向量、BM25 和结构化过滤检索。
 </td>
 <td width="33%" valign="top">
+<strong>Layered Memory Model</strong><br>
+用户记忆和 Agent 记忆现在是一等公民。Wiki 式知识层是路线图中的下一层。
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
 <strong>Self-Evolving Agents</strong><br>
-Agent 可以从重复工作流中沉淀可复用的 cases 和 skills，并随着使用持续改进。
+Agent 记忆可以从重复经验中提取可复用的 cases 和 skills，让工作流随着时间变得更聪明。
+</td>
+<td width="33%" valign="top">
+<strong>Multimodal Ingestion</strong><br>
+文本、图片、音频、文档、PDF、HTML 和邮件都可以通过可选的多模态管线解析进记忆。
+</td>
+<td width="33%" valign="top">
+<strong>Online And Offline Strategy Control</strong><br>
+在线提取和离线进化保持分离，并且每一步都可以配置 prompts 和 models。Dreaming 即将到来。
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+<strong>Orthogonal Memory Scope</strong><br>
+Owner、memory type 和 scope 相互独立：可以按 user、agent、app、project、session 和结构化 filters 搜索。
+</td>
+<td width="33%" valign="top">
+<strong>Progressive Disclosure</strong><br>
+可读记忆界面保持简单，同时更深层的 facts、cases 和 skills 仍然可以被系统使用。
+</td>
+<td width="33%" valign="top">
+<strong>Modular By Design</strong><br>
+EverAlgo 负责算法；EverOS 负责运行时、持久化、在线流程和离线进化。
 </td>
 </tr>
 </table>
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
 
 ## 什么是 EverOS
 
 EverOS 是一个开源 Python 框架，用来构建**跨 Agent、跨平台的自进化长期记忆**。
-它让 maker 可以为所有常用 Agent 维护同一套可携带的记忆层，例如
-Claude Code、Codex、OpenClaw、Hermes 等，让上下文、决策、文件和
-Agent 轨迹跟着工作流走，而不是被锁在某一个工具里。
+它为 maker 提供一层可携带的统一记忆层，适用于他们使用的每一个 Agent：
+Claude Code、Codex、OpenClaw、Hermes 等等。这样，上下文、决策、文件和
+Agent 轨迹可以跟着工作流走，而不是被锁在某一个工具里。
 
-EverOS 会把对话、Agent 轨迹和文件保存为可读的 Markdown，并同步本地
-SQLite 与 LanceDB 索引，方便快速检索。Agent 可以复用过去的 cases
-和 skills，从重复工作中自我改进，并逐渐变得更加主动。
+EverOS 会把对话、Agent 轨迹和文件保存为可读 Markdown，并同步本地 SQLite
+和 LanceDB 索引，以便快速检索。Agent 可以复用过去的 cases 和 skills，从重复
+工作流中自我改进，并逐渐变得更加主动。
 
-EverOS 的核心边界：
+系统围绕三个边界设计：
 
-1. **记忆内容保持可读** - Markdown 是长期记忆的 source of truth。
-2. **运行时状态保持本地** - SQLite 负责状态，LanceDB 负责向量、BM25 和结构化过滤。
-3. **算法保持模块化** - EverAlgo 负责记忆算法，EverOS 负责运行时、持久化、在线流程和离线进化。
+1. **记忆内容保持可读** - Markdown 是长期、耐用的 source of truth。
+2. **运行时状态保持本地** - SQLite 跟踪状态；LanceDB 处理向量、BM25 和结构化过滤搜索。
+3. **算法保持模块化** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) 负责记忆算法；EverOS 负责运行时、持久化、在线流程和离线进化。
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
 
 ## 快速开始
 
@@ -94,11 +140,13 @@ uv pip install everos
 
 ### 2. 初始化配置
 
+生成一个 starter `.env` 文件，然后根据生成的注释填入 API key 字段。
+
 ```bash
 everos init
 ```
 
-`everos init` 默认写入 `./.env`。你也可以使用 `everos init --xdg`
+`everos init` 默认写入 `./.env`。也可以使用 `everos init --xdg`
 写入 `${XDG_CONFIG_HOME:-~/.config}/everos/.env`。
 
 ### 3. 启动服务
@@ -108,11 +156,60 @@ everos --help
 everos server start
 ```
 
-EverOS 的端点兼容 OpenAI protocol，可以接入 OpenAI、OpenRouter、
-vLLM、Ollama、DeepInfra 等服务。修改 `.env` 中的 `*__BASE_URL`
-即可指向对应模型服务。
+`everos server start` 会按以下顺序查找 `.env`：`--env-file <path>` →
+`./.env`（当前目录）→ `${XDG_CONFIG_HOME:-~/.config}/everos/.env` →
+`~/.everos/.env`。端点栈兼容 OpenAI protocol（OpenAI / OpenRouter /
+vLLM / Ollama / DeepInfra）。你可以覆盖生成的 `.env` 中的 `*__BASE_URL`
+来指向任意这些模型服务。
+
+完整 walkthrough（添加对话、flush、search，然后读取 Markdown）见
+[QUICKSTART.md](QUICKSTART.md)。
+
+### 可选：摄取多模态文件
+
+如果要通过 `/api/v1/memory/add` 的 `content` items 摄取非文本内容
+（image / pdf / audio / office documents），安装可选 extra：
+
+```bash
+uv pip install 'everos[multimodal]'   # or: pip install 'everos[multimodal]'
+```
+
+这会引入 `everalgo-parser`（包含用于 SVG 支持的 `[svg]` bundle，通过
+cairosvg）并接入多模态 LLM client（`.env` 中的 `EVEROS_MULTIMODAL__*`
+字段，默认通过 OpenRouter 使用 `google/gemini-3-flash-preview`）。
+
+**Office 文档支持需要 LibreOffice 作为系统依赖。** parser 会调用
+`soffice`（LibreOffice 的 headless renderer），先把 `.doc` / `.docx` /
+`.ppt` / `.pptx` / `.xls` / `.xlsx` 转换为 PDF，再交给多模态 LLM。
+如果没有 LibreOffice，office 上传会返回 HTTP 415，并带有明确错误信息；
+PDF / image / audio / HTML / email 解析不受影响。
+
+在提供 office 文档服务前，请先在宿主机安装：
+
+```bash
+brew install --cask libreoffice              # macOS
+sudo apt-get install -y libreoffice          # Debian / Ubuntu
+```
+
+### 贡献者开发
+
+```bash
+git clone https://github.com/EverMind-AI/EverOS.git
+cd EverOS
+uv sync                              # creates ./.venv and installs deps
+source .venv/bin/activate            # or prefix commands with `uv run`
+everos init                          # fill the four API key slots in .env (two distinct keys)
+
+everos --help
+make test
+```
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## 架构概览
 
@@ -134,53 +231,537 @@ vLLM、Ollama、DeepInfra 等服务。修改 `.env` 中的 `*__BASE_URL`
 DDD 5 层架构，单向依赖。详见 [docs/architecture.md](docs/architecture.md)。
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## 存储布局
+
+```
+~/.everos/
+├── default_app/                  # app_id  ("default" → "default_app" on disk)
+│   └── default_project/          # project_id ("default" → "default_project")
+│       ├── users/<user_id>/
+│       │   ├── user.md           # profile
+│       │   ├── episodes/         # daily-log episodes (visible)
+│       │   ├── .atomic_facts/    # nested facts (dotfile-hidden)
+│       │   └── .foresights/      # predictive memory (dotfile-hidden)
+│       └── agents/<agent_id>/
+│           ├── agent.md
+│           ├── .cases/           # one task case per entry
+│           └── skills/           # named procedural memories
+├── .index/                       # derived indexes (rebuildable from md)
+│   ├── sqlite/system.db          # state + queue + audit
+│   └── lancedb/*.lance/          # vector + BM25 + scalar
+└── .tmp/                         # transient working files
+```
+
+在 Obsidian 中打开任意 `<app>/<project>/users/<user_id>/` 文件夹即可。
+你的 Agent 大脑本质上就是一组文件。dotfile 目录（`.atomic_facts/`、
+`.foresights/`、`.cases/`）默认保持隐藏，因此可见文件夹仍然是面向用户的
+记忆表面，而提取出的衍生信息则安静地放在旁边。
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## 功能
 
-- **Hybrid Retrieval**: BM25 + vector + scalar filter，统一由 LanceDB 查询
-- **Cascade Index Sync**: 修改 `.md` 后自动 diff 并同步到 LanceDB
-- **Multi-Source Extraction**: 支持对话、Agent 轨迹、文件知识
-- **Dual-Track Memory**: 用户记忆和 Agent 记忆分层管理
-- **Multimodal Ingestion**: 支持文本、图片、音频、PDF、Office 文档等
-- **Modular Algorithms**: EverAlgo 负责可复用的算法层
+- **混合检索**: BM25 + vector（HNSW/IVF-PQ）+ scalar filter，在 LanceDB 中完成单次查询
+- **级联索引同步**: 编辑 `.md` → file watcher → entry-level diff → LanceDB sync，亚秒级同步
+- **多源提取**: conversations / agent trajectories / file knowledge
+- **双轨记忆**: user-track（Episodes / Profiles）+ agent-track（Cases / Skills）
+- **异步优先**: 完整 asyncio，单一 event loop
+- **多模态**: text + 小图片 / audio inline；大媒体通过 S3/OSS reference
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## 项目结构
+
+```
+everos/                        # repo root
+├── src/everos/                # main package (src layout)
+│   ├── entrypoints/           # cli + api
+│   ├── service/               # use case orchestration
+│   ├── memory/                # domain: extract + search + cascade + prompt_slots
+│   ├── infra/                 # storage: markdown + lancedb + sqlite
+│   ├── component/             # cross-cutting: llm / embedding / config / utils
+│   ├── core/                  # runtime: observability / lifespan / context
+│   └── config/                # configuration data + Settings schema
+├── tests/                     # unit / integration / golden / fixtures
+├── docs/                      # design docs
+└── .claude/                   # team-shared rules + skills (auto-loaded by Claude Code)
+```
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## 文档
 
-- [QUICKSTART.md](QUICKSTART.md) - 快速上手
-- [docs/overview.md](docs/overview.md) - 项目愿景与概览
-- [docs/architecture.md](docs/architecture.md) - 架构设计
-- [docs/api.md](docs/api.md) - API 文档
-- [docs/use-cases.md](docs/use-cases.md) - 用例集合
-- [CHANGELOG.md](CHANGELOG.md) - 版本记录
+- [docs/overview.md](docs/overview.md) - 项目概览与愿景
+- [docs/architecture.md](docs/architecture.md) - DDD 分层架构与依赖规则
+- [docs/engineering.md](docs/engineering.md) - 工程与开发效率基础设施（CI / tooling / Claude Code）
+- [docs/use-cases.md](docs/use-cases.md) - 完整使用场景 gallery 和集成示例
+- [docs/migration-to-1.0.0.md](docs/migration-to-1.0.0.md) - Legacy API 与基础设施迁移说明
+- [CHANGELOG.md](CHANGELOG.md) - 发布记录
+- [CONTRIBUTING.md](CONTRIBUTING.md) - 如何贡献
+- [.claude/rules/](.claude/rules/) - 详细代码规范（Claude Code 会自动加载）
 
 <br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+
+## 使用场景
+
+这些使用场景展示了持久记忆可以在真实产品和工作流中带来什么能力。
+有些示例已经打包在本仓库中，另一些则指向外部 demo 或集成，你可以研究并复用。
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
+
+#### Reunite - 用 EverOS 找回连接
+
+父母描述他们记得的线索，孩子描述他们残留的回忆。Reunite 使用语义记忆来浮现这些连接。
+
+[了解更多](https://evermind.ai/usecase_reunite)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
+
+#### Hive Orchestrator
+
+面向 CLI coding agents 的 browser-native hive-mind。Claude Code、Codex、Gemini 和 OpenCode 作为真实 PTY 进程，通过团队协议协作。
+
+[代码](https://github.com/tt-a1i/hive)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
+
+#### 接入 EverOS 的 AI 编程助手
+
+由 EverOS 驱动的通用长期记忆层，面向 AI coding assistants。
+
+[代码](https://github.com/tt-a1i/evermemos-mcp)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
+
+#### AI Data Technician
+
+一个 agentic AI 系统，可以从科学家的交互中学习，用于检查、分析和分类高维时间序列数据，并通过跨 session 改进的持久记忆持续变强。
+
+[代码](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
+
+#### 接入 EverOS 的 Rokid AI 助手
+
+在 Rokid Glasses 中连接 EverOS，为你的智能活动启用长期记忆。
+
+即将推出
+
+</td>
+<td width="50%" valign="top">
+
+![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
+
+#### 带长期记忆的创意助手
+
+拥有长期记忆的创意助手，让你的创作上下文可以跨 session 持续可用。
+
+即将推出
+
+</td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
+
+#### Earth Online 记忆游戏
+
+Earth Online 是一款 memory-aware productivity game，把日常计划变成一个持续生长的 quest log。
+
+[代码](https://github.com/xunyud/Earth-Online)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
+
+#### 多 Agent 编排平台
+
+Golutra 为工程团队提供 multi-agent workforce，把 IDE 从单一 assistant 扩展为协同 agents。
+
+[代码](https://github.com/golutra/golutra)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
+
+#### 你的个人品鉴宇宙
+
+通过沉浸式 3D 星图记录、可视化并探索你的 tasting journey。
+
+[代码](https://github.com/Yangtze-Seventh/taste-verse)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
+
+#### EverOS Open Her
+
+构建有感受的 AI。开源 persona engine，让 personality 从 neural drives 中涌现，而不是来自 prompts。灵感来自 Her。
+
+[代码](https://github.com/kellyvv/OpenHer)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
+
+#### 面向个人记忆的浏览器 Agent
+
+Ruminer 为 browser agent 带来持久记忆，让它能在不同网页任务之间携带个人上下文。
+
+[插件](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
+
+#### EverMem 与 EverOS 同步
+
+一条命令，把任意 AI coding CLI 连接到 EverMemOS 长期记忆。
+
+[代码](https://github.com/nanxingw/EverMem)
+
+</td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
+
+#### MCO - 编排 AI Coding Agents
+
+MCO 为你的主 Agent 配备一个 agent team，让它们可以一起处理复杂任务。
+
+[代码](https://github.com/mco-org/mco)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
+
+#### 带自进化记忆的 Study Buddy
+
+使用拥有 self-evolving memory 的 Agent，主动辅助学习。
+
+[代码](https://github.com/onenewborn/StudyBuddy-public)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
+
+#### 阿尔茨海默症记忆助手
+
+通过高级记忆支持和日常辅助，帮助有需要的人更好地生活。
+
+[代码](https://github.com/TonyLiangDesign/MemoCare)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
+
+#### 记忆驱动的 Multi-Agent NPC 体验
+
+一款 iOS 科幻悬疑游戏，玩家可以探索世界并揭开真相。
+
+[代码](https://github.com/AlexL1024/NeuralConnect)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
+
+#### Mobi Companion
+
+一款 iOS app，用户可以创建、养成并与名为 Mobi 的个性化 AI companion 一起生活。
+
+[代码](https://github.com/elontusk5219-prog/Mobi)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
+
+#### 带记忆的 AI 可穿戴设备
+
+一个 context-native AI wearable，聆听日常生活，并把对话转换为记忆。
+
+[代码](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
+
+</td>
+</tr>
+
+<tr>
+<td colspan="2" align="right">
+<a href="#readme-top"><img src="https://img.shields.io/badge/-Back_to_top-gray?style=flat-square" alt="Back to top"></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](docs/migration-to-1.0.0.md)
+
+#### Legacy OpenClaw Agent 记忆
+
+已归档的 pre-1.0.0 plugin reference。新的集成应使用 EverOS 1.0.0 API。
+
+[了解更多](docs/migration-to-1.0.0.md)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
+
+#### 带记忆的 Live2D 角色
+
+为实时 Live2D character 添加长期记忆，由 [TEN Framework](https://github.com/TEN-framework/ten-framework) 驱动。
+
+[代码](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
+
+#### 带记忆的 Computer-Use
+
+运行基于截图的分析任务，并把结果存入记忆。
+
+[在线演示](https://screenshot-analysis-vercel.vercel.app/)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](use-cases/game-of-throne-demo)
+
+#### Game Of Thrones Memories
+
+通过与 *A Game of Thrones* 互动问答体验，展示 AI 记忆基础设施。
+
+[代码](use-cases/game-of-throne-demo)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](use-cases/claude-code-plugin)
+
+#### Claude Code Plugin
+
+Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 的上下文。
+
+[代码](use-cases/claude-code-plugin)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
+
+#### 记忆图谱可视化
+
+在图界面中探索已存储的 entities 和 relationships。前端 demo 已可用；后端集成仍在进行中。
+
+[在线演示](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
+
+</td>
+</tr>
+</table>
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+## 持续关注
+
+Star 这个仓库，或加入上面的社区链接，以持续关注新的架构方法、benchmark releases、
+memory-enabled use cases、Wiki 式记忆和 Dreaming 更新。
+
+![star us gif](https://github.com/user-attachments/assets/0c512570-945a-483a-9f47-8e067bd34484)
+
+### Star 趋势
+
+[![Star 趋势图](https://api.star-history.com/svg?repos=EverMind-AI/EverOS&type=Date)](https://www.star-history.com/#EverMind-AI/EverOS&Date)
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 ## EverMind 生态
 
-EverMind 是面向长期记忆、自进化 Agent 和记忆评测的开源生态。
-EverOS 是核心运行时；EverAlgo 提供算法引擎；EverMemBench 和
-EvoAgentBench 提供评测基准；EverMe 和相关插件面向跨设备、跨 Agent
-的个人记忆工作流。
+EverMind 是一个面向长期记忆、自进化 Agent 和记忆评测的开源生态。
+EverOS 是核心运行时架构；EverMemOS 是论文与研究线，承载我们最强的
+memory-system benchmark runs；EverAlgo 提供让系统保持模块化和可复用的下一代算法。
 
-相关仓库：
+<table>
+<tr>
+<th colspan="2">EverMind 开源生态</th>
+</tr>
+<tr>
+<td><strong>核心记忆架构</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> / EverMemOS - 本地记忆操作系统，以及有研究支撑的 Agent 和用户记忆运行时。</td>
+</tr>
+<tr>
+<td><strong>算法引擎</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> - stateless extraction、ranking、parsing 和 memory operators，为 EverOS 提供算法能力。</td>
+</tr>
+<tr>
+<td><strong>替代架构</strong></td>
+<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> - 面向长期对话的 hypergraph memory，拥有独立的 benchmark-backed topic -> episode -> fact 检索方法。</td>
+</tr>
+<tr>
+<td><strong>Benchmarks</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> - conversational memory 和 Agent self-evolution 的评测套件。</td>
+</tr>
+<tr>
+<td><strong>Long-Context Research</strong></td>
+<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> - Memory Sparse Attention，用于可扩展 latent memory 和 100M-token contexts。</td>
+</tr>
+<tr>
+<td><strong>个人记忆层</strong></td>
+<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> - CLI 和 Agent plugin suite，用于跨设备、跨 Agent 的个人记忆。</td>
+</tr>
+<tr>
+<td><strong>开发者集成</strong></td>
+<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> - AI coding agents 的 plugins、skills 和 migration tooling。</td>
+</tr>
+</table>
 
-- [EverOS](https://github.com/EverMind-AI/EverOS)
-- [EverAlgo](https://github.com/EverMind-AI/EverAlgo)
-- [HyperMem](https://github.com/EverMind-AI/HyperMem)
-- [EverMemBench](https://github.com/EverMind-AI/EverMemBench)
-- [EvoAgentBench](https://github.com/EverMind-AI/EvoAgentBench)
-- [EverMe](https://github.com/EverMind-AI/EverMe)
+这些仓库共同构成 EverMind 的 research-to-runtime stack：新的记忆方法、可复用算法、
+benchmark evidence，以及可落地的 Agent 集成。
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
 
 <br>
 
-## Star History
+## 参与贡献
 
-关注 EverOS 的社区增长，也欢迎 Star 和 Watch 这个仓库，持续跟进
-EverOS 1.0.0 之后的 Wiki 式知识层、Dreaming 离线进化和 Agent 记忆能力。
+欢迎为整个仓库贡献：架构方法、benchmark coverage、use-case examples、文档和 bug fixes。
+浏览 [Issues](https://github.com/EverMind-AI/EverOS/issues) 找到适合的切入点，
+准备好后即可提交 PR。
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/EverOS&type=Date)](https://www.star-history.com/#EverMind-AI/EverOS&Date)
+<br>
+
+> [!TIP]
+>
+> **欢迎各种形式的贡献** 🎉
+>
+> 一起让 EverOS 变得更好。代码、文档、benchmark reports、use-case write-ups
+> 和 integration examples 都很有价值。也欢迎在社交媒体上分享你的项目，启发更多人。
+>
+> 你可以在 𝕏 上联系 EverOS maintainer [@elliotchen200](https://x.com/elliotchen200)，
+> 或在 GitHub 上联系 [@cyfyifanchen](https://github.com/cyfyifanchen)，获取项目更新、
+> 讨论和协作机会。
+
+![divider](https://github.com/user-attachments/assets/2e2bbcc6-e6d8-4227-83c6-0620fc96f761#gh-light-mode-only)
+![divider](https://github.com/user-attachments/assets/d57fad08-4f49-4a1c-bdfc-f659a5d86150#gh-dark-mode-only)
+
+### 代码贡献者
+
+[![EverOS Contributors](https://contrib.rocks/image?repo=EverMind-AI/EverOS)](https://github.com/EverMind-AI/EverOS/graphs/contributors)
+
+![divider](https://github.com/user-attachments/assets/2e2bbcc6-e6d8-4227-83c6-0620fc96f761#gh-light-mode-only)
+![divider](https://github.com/user-attachments/assets/d57fad08-4f49-4a1c-bdfc-f659a5d86150#gh-dark-mode-only)
+
+### 许可证
+
+[Apache License 2.0](LICENSE) - 第三方归属说明请见 [NOTICE](NOTICE)。
+
+### 引用
+
+如果你在研究中使用 EverOS，请参考 [CITATION.md](CITATION.md)。
 
 <br>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ Top-level project files live next to the repo root:
 
 - [README.md](../README.md) — quick start & feature overview
 - [QUICKSTART.md](../QUICKSTART.md) — 5-minute walkthrough (install → service → search)
+- [use-cases.md](use-cases.md) — full use-case gallery and integration examples
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — how to contribute (issue-only model)
 - [CHANGELOG.md](../CHANGELOG.md) — release notes
 - [SECURITY.md](../SECURITY.md) — security policy & private vulnerability reporting

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,307 @@
+# EverOS Use Cases
+
+Use cases show what persistent memory makes possible in real products and
+workflows. Some examples are packaged in this repository; others point to
+external demos or integrations you can study and adapt.
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/840470d7-a838-4c05-8685-dd797d4e9cdf)](https://evermind.ai/usecase_reunite)
+
+#### Reunite - Find with EverOS
+
+Parents describe what they remember. Children describe what they recall. Reunite uses semantic memory to surface the connections.
+
+[Learn more](https://evermind.ai/usecase_reunite)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/7282b38b-56bf-4356-aa7b-06a845e7683d)](https://github.com/tt-a1i/hive)
+
+#### Hive Orchestrator
+
+Browser-native hive-mind for CLI coding agents - Claude Code, Codex, Gemini, and OpenCode collaborate as real PTY processes via a team protocol.
+
+[Code](https://github.com/tt-a1i/hive)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/867d9329-ce9a-496f-ab1e-15c77974e5fa)](https://github.com/tt-a1i/evermemos-mcp)
+
+#### AI Coding Assistants with EverOS
+
+Universal long-term memory layer for AI coding assistants, powered by EverOS.
+
+[Code](https://github.com/tt-a1i/evermemos-mcp)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/a4f0fd86-1c81-4445-bebc-e51eb5e33b30)](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
+
+#### AI Data Technician
+
+An agentic AI system that learns from scientist interaction to inspect, analyze, and classify high-dimensional time series data - with persistent memory that improves across sessions.
+
+[Code](https://github.com/yuansui123/AI-Data-Technician-EverMemOS)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+![banner-gif](https://github.com/user-attachments/assets/650b901b-c9ba-4001-bac7-626b009df830)
+
+#### Rokid AI Assistant with EverOS
+
+Connect to EverOS within Rokid Glasses enabling long-term memory for all of your smart activities.
+
+Coming soon
+
+</td>
+<td width="50%" valign="top">
+
+![banner-gif](https://github.com/user-attachments/assets/85b338b2-e48e-4a65-9f30-0bc6998df872)
+
+#### Creative Assistant with Memory
+
+Creative assistant with long-term memory, so your creative context stays available across sessions.
+
+Coming soon
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/f30617a1-adc0-4271-bc0e-c3a0b28cb903)](https://github.com/xunyud/Earth-Online)
+
+#### Earth Online Memory Game
+
+Earth Online is a memory-aware productivity game that turns everyday planning into a living quest log.
+
+[Code](https://github.com/xunyud/Earth-Online)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/57d8cda7-35a5-4561-b794-5520dffc917b)](https://github.com/golutra/golutra)
+
+#### Multi-Agent Orchestration Platform
+
+Golutra presents a multi-agent workforce for engineering teams, extending the IDE model from a single assistant to coordinated agents.
+
+[Code](https://github.com/golutra/golutra)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/75f19db5-30f6-4eed-9b1e-c9c6a0e6b7de)](https://github.com/Yangtze-Seventh/taste-verse)
+
+#### Your Personal Tasting Universe
+
+Record, visualize, and explore your tasting journey through an immersive 3D star map.
+
+[Code](https://github.com/Yangtze-Seventh/taste-verse)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/93ac2a68-4f18-4fcb-8d87-80aeb00a9d7c)](https://github.com/kellyvv/OpenHer)
+
+#### EverOS Open Her
+
+Build AI that feels. Open-source persona engine - personality emerges from neural drives, not prompts. Inspired by Her.
+
+[Code](https://github.com/kellyvv/OpenHer)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/550071c1-dc39-4964-9f67-ffdfad792345)](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
+
+#### Browser Agent for Personal Memory
+
+Ruminer brings persistent memory to a browser agent so it can carry personal context across web tasks.
+
+[Plugin](https://chromewebstore.google.com/detail/ruminer-browser-agent/lbccjohfpdpimbhpckljimgolndfmfif)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/c258a6c4-fe70-497a-98d1-3dade4a932f6)](https://github.com/nanxingw/EverMem)
+
+#### EverMem Sync with EverOS
+
+One command to connect any AI coding CLI to EverMemOS long-term memory.
+
+[Code](https://github.com/nanxingw/EverMem)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/39274473-ceb3-48fb-a031-e22230decbe2)](https://github.com/mco-org/mco)
+
+#### MCO - Orchestrate AI Coding Agents
+
+MCO equips your primary agent with an agent team that can work together to solve complex tasks.
+
+[Code](https://github.com/mco-org/mco)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/314c9126-8e08-4688-bbbb-8555ad58cf67)](https://github.com/onenewborn/StudyBuddy-public)
+
+#### Study Buddy with Self-Evolving Memory
+
+Study proactively with an agent that has self-evolving memory.
+
+[Code](https://github.com/onenewborn/StudyBuddy-public)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/21da76aa-9a8b-48e0-9134-42429d7390e7)](https://github.com/TonyLiangDesign/MemoCare)
+
+#### Alzheimer's Memory Assistant
+
+Empowering individuals with advanced memory support and daily assistance.
+
+[Code](https://github.com/TonyLiangDesign/MemoCare)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/e2428df3-ea11-4e88-8f9c-dad437dd8998)](https://github.com/AlexL1024/NeuralConnect)
+
+#### Memory-Driven Multi-Agent NPC Experience
+
+An iOS sci-fi mystery game where players explore and uncover the truth.
+
+[Code](https://github.com/AlexL1024/NeuralConnect)
+
+</td>
+</tr>
+
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/e6eaf308-a874-483f-8874-6934bf95a78f)](https://github.com/elontusk5219-prog/Mobi)
+
+#### Mobi Companion
+
+An iOS app where users create, nurture, and live with a personalized AI companion called Mobi.
+
+[Code](https://github.com/elontusk5219-prog/Mobi)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/9aabcaa9-f97a-49d2-9109-0b5bb696ed41)](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
+
+#### AI Wearable with Memory
+
+A context-native AI wearable that listens to everyday life and converts conversations into memory.
+
+[Code](https://github.com/JaMesLiMers/EvermemCompetition-Spiro)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/df9677ec-386f-4c56-a428-08bca25c54dc)](migration-to-1.0.0.md)
+
+#### Legacy OpenClaw Agent Memory
+
+Archived pre-1.0.0 plugin reference. New integrations should use the EverOS 1.0.0 API.
+
+[Learn more](migration-to-1.0.0.md)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/3a2357a1-c0c3-464a-8979-0d1cdfc9b0d4)](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
+
+#### Live2D Character with Memory
+
+Add long-term memory to a real-time Live2D character, powered by [TEN Framework](https://github.com/TEN-framework/ten-framework).
+
+[Code](https://github.com/TEN-framework/ten-framework/tree/04cb80601374fa9e35b4e544b2dbd23286ca7763/ai_agents/agents/examples/voice-assistant-with-EverMemOS)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/c36bdc04-97d3-4fe9-97d9-4b93b475595a)](https://screenshot-analysis-vercel.vercel.app/)
+
+#### Computer-Use with Memory
+
+Run screenshot-based analysis with computer-use and store the results in memory.
+
+[Live Demo](https://screenshot-analysis-vercel.vercel.app/)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/54a7cf8f-62c4-4fbc-9d50-b214d034e051)](../use-cases/game-of-throne-demo)
+
+#### Game of Thrones Memories
+
+A demonstration of AI memory infrastructure through an interactive Q&A experience with *A Game of Thrones*.
+
+[Code](../use-cases/game-of-throne-demo)
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/af37c1f6-7ba5-430c-b99d-2a7e7eac618f)](../use-cases/claude-code-plugin)
+
+#### Claude Code Plugin
+
+Persistent memory for Claude Code. Automatically saves and recalls context from past coding sessions.
+
+[Code](../use-cases/claude-code-plugin)
+
+</td>
+<td width="50%" valign="top">
+
+[![banner-gif](https://github.com/user-attachments/assets/d521d28c-0ccd-44ff-aecc-828245e2f973)](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
+
+#### Memory Graph Visualization
+
+Explore stored entities and relationships in a graph interface. Frontend demo; backend integration is in progress.
+
+[Live Demo](https://main.d2j21qxnymu6wl.amplifyapp.com/graph.html)
+
+</td>
+</tr>
+</table>
+
+<br>
+
+[Back to README](../README.md)


### PR DESCRIPTION
This draft PR carries the README launch polish stack for review and further iteration. It keeps the top EverOS 1.0.0 launch messaging, reduces the visible highlight table to four stronger points, keeps the Chinese README aligned, and retains the related docs/use-case updates from the current branch.\n\nChecks run locally: git diff --check -- README.md README.zh-CN.md.\n\nLeaving this unmerged so we can continue making additional changes on this PR.