### PR TITLE
docs: explain upcoming knowledge wiki and reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 <br>
 
 - [EverOS 1.0.0](#everos-100)
-- [Why EverOS](#why-everos)
-- [How EverOS Is Different](#how-everos-is-different)
+- [EverMe: One Memory For All](#everme-one-memory-for-all)
+- [How EverMe Is Different](#how-everme-is-different)
 - [Quick Start](#quick-start)
 - [Architecture At A Glance](#architecture-at-a-glance)
 - [Storage Layout](#storage-layout)
@@ -62,24 +62,56 @@
 </div>
 
 
-## Why EverOS
+## EverMe: One Memory For All
 
-EverOS is an open-source Python framework for self-evolving long-term
-memory across agents and platforms. It gives makers one portable memory
-layer for every agent they use - Claude Code, Codex, OpenClaw, Hermes,
-and more - so context, decisions, files, and trajectories can follow the
-work instead of staying trapped in one tool.
+<table>
+<tr>
+<td width="33%" valign="top">
+<strong>Markdown As Source Of Truth</strong><br>
+<br>
+All memory is persisted as <code>.md</code> files: readable, editable,
+grep-able, Git-versioned, and openable directly in Obsidian.
+</td>
+<td width="33%" valign="top">
+<strong>Local Three-Part Stack</strong><br>
+<br>
+Markdown + SQLite + LanceDB keep vectors, BM25, and scalar filters
+local. No MongoDB, Elasticsearch, or Redis required.
+</td>
+<td width="33%" valign="top">
+<strong>Dual-Track Memory</strong><br>
+<br>
+Agent memory (<code>cases</code> / <code>skills</code>) and user memory
+(<code>episodes</code> / <code>profile</code>) are extracted independently.
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+<strong>Multimodal Ingestion</strong><br>
+<br>
+Text, images, audio, documents, PDFs, HTML, and email are unified into
+searchable memory.
+</td>
+<td width="33%" valign="top">
+<strong>Self-Evolution</strong><br>
+<br>
+Common skills are extracted from real usage; repeated patterns become
+reusable workflows, no retraining required.
+</td>
+<td width="33%" valign="top">
+<strong>Orthogonal Retrieval</strong><br>
+<br>
+Search independently by <code>user_id</code>, <code>agent_id</code>,
+<code>app_id</code>, <code>project_id</code>, and <code>session_id</code>.
+</td>
+</tr>
+</table>
 
-EverOS stores conversations, agent trajectories, and files as readable
-Markdown, then syncs local SQLite and LanceDB indexes for fast retrieval.
-Agents can reuse past cases and skills, improve from repeated workflows,
-and become more proactive over time.
-
-The system is built around three boundaries:
-
-1. **Memory content stays readable** - Markdown is the durable source of truth.
-2. **Runtime state stays local** - SQLite tracks state and LanceDB handles vector, BM25, and scalar-filter search.
-3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
+EverMe is the personal-memory experience built on EverOS: a CLI and agent
+plugin layer that lets one memory follow a maker across coding assistants,
+apps, devices, and workflows. Today it stores conversations, files, and agent
+trajectories as readable Markdown, then syncs local SQLite and LanceDB indexes
+for fast retrieval and self-evolving reuse.
 
 <br>
 <div align="right">
@@ -89,61 +121,53 @@ The system is built around three boundaries:
 </div>
 
 
-## How EverOS Is Different
+## How EverMe Is Different
 
 The table below compares common memory-library architectures rather than naming
 specific repos. Some projects overlap categories, and some do expose
-file-oriented or Markdown-like surfaces. EverOS is different because Markdown is
+file-oriented or Markdown-like surfaces. EverMe is different because Markdown is
 the canonical memory layer, not just an export, log, or integration target.
 
 <table>
 <tr>
-<th width="24%">Developer need</th>
-<th width="28%">EverOS default</th>
-<th width="24%">Typical memory libraries</th>
-<th width="24%">File / Markdown-adjacent tools</th>
+<th width="28%">Title</th>
+<th width="36%">EverMe</th>
+<th width="36%">Agent Memory libraries</th>
 </tr>
 <tr>
-<td><strong>Markdown source of truth</strong><br><sub>Memory is readable, editable, diffable, and Git-versioned as files.</sub></td>
-<td>✅ Canonical <code>.md</code> memory</td>
+<td><strong>Markdown source of truth</strong></td>
+<td>✅ Canonical <code>.md</code> files that are readable, editable, diffable, and Git-versioned</td>
 <td>❌ Usually API, vector, graph, dashboard, or database state</td>
-<td>✅ Often readable, but not always the full runtime source of truth</td>
 </tr>
 <tr>
-<td><strong>Direct file editing</strong><br><sub>Edit memory with normal developer tools, then sync indexes.</sub></td>
+<td><strong>Direct file editing</strong></td>
 <td>✅ Edit <code>.md</code> files; cascade watcher syncs</td>
 <td>❌ Usually SDK, API, dashboard, or backend update paths</td>
-<td>✅ Sometimes possible, but often without entry-level index sync</td>
 </tr>
 <tr>
-<td><strong>Local three-part stack</strong><br><sub>Markdown + SQLite + LanceDB; no MongoDB, Elasticsearch, or Redis required.</sub></td>
-<td>✅ Built in</td>
+<td><strong>Local three-part stack</strong></td>
+<td>✅ Markdown + SQLite + LanceDB; no MongoDB, Elasticsearch, or Redis required</td>
 <td>❌ Often depends on managed services, vector DBs, graph DBs, or server stacks</td>
-<td>❌ Often local, but commonly tied to a different index/backend model</td>
 </tr>
 <tr>
-<td><strong>User + agent memory tracks</strong><br><sub>User <code>episodes/profile</code> and agent <code>cases/skills</code> are separate first-class surfaces.</sub></td>
-<td>✅ Built in</td>
+<td><strong>User + agent tracks</strong></td>
+<td>✅ User <code>episodes/profile</code> and agent <code>cases/skills</code> are separate first-class surfaces</td>
 <td>❌ Usually centered on chat history, profiles, entities, facts, or retrieval records</td>
-<td>❌ Usually centered on logs, notes, projects, or conversations</td>
 </tr>
 <tr>
-<td><strong>Orthogonal retrieval scopes</strong><br><sub>Search by <code>user_id</code>, <code>agent_id</code>, <code>app_id</code>, <code>project_id</code>, and <code>session_id</code>.</sub></td>
-<td>✅ Built in</td>
+<td><strong>Orthogonal retrieval</strong></td>
+<td>✅ Search by <code>user_id</code>, <code>agent_id</code>, <code>app_id</code>, <code>project_id</code>, and <code>session_id</code></td>
 <td>❌ Usually app, namespace, tenant, thread, or graph scoped</td>
-<td>❌ Usually folder, project, or conversation scoped</td>
 </tr>
 <tr>
-<td><strong>Knowledge Wiki</strong><br><sub>Memory should become editable, source-backed knowledge pages.</sub></td>
+<td><strong>Knowledge Wiki</strong></td>
 <td>✅ Coming next: Markdown wiki pages derived from memory</td>
 <td>❌ Usually retrieval, graph, dashboard, or generated summary state</td>
-<td>✅ Often wiki-like, but usually manual or separate from runtime memory</td>
 </tr>
 <tr>
-<td><strong>Dreaming / Reflection</strong><br><sub>Offline consolidation should connect signals and improve long-term behavior.</sub></td>
+<td><strong>Dreaming / Reflection</strong></td>
 <td>✅ Coming next: offline Reflection across profiles, skills, and wiki</td>
 <td>❌ Usually online read/write APIs rather than file-native self-improvement</td>
-<td>❌ Usually note recall or summaries, not runtime memory evolution</td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -123,16 +123,11 @@ retrieval and self-evolving reuse.
 
 ## How EverOS Is Different
 
-The table below compares common memory-library architectures rather than naming
-specific repos. Some projects overlap categories, and some do expose
-file-oriented or Markdown-like surfaces. EverOS is different because Markdown is
-the canonical memory layer, not just an export, log, or integration target.
-
 <table>
 <tr>
 <th width="28%">Title</th>
 <th width="36%">EverOS</th>
-<th width="36%">Agent Memory libraries</th>
+<th width="36%">Other Agent Memory Libraries</th>
 </tr>
 <tr>
 <td><strong>Markdown source of truth</strong></td>
@@ -161,17 +156,15 @@ the canonical memory layer, not just an export, log, or integration target.
 </tr>
 <tr>
 <td><strong>Knowledge Wiki</strong></td>
-<td>✅ Coming next: Markdown wiki pages derived from memory</td>
-<td>❌ Usually retrieval, graph, dashboard, or generated summary state</td>
+<td>✅ Coming next: editable, source-backed Markdown knowledge pages built from memory</td>
+<td>❌ Usually retrieval, graph, dashboards, or generated summaries instead of editable source-backed pages</td>
 </tr>
 <tr>
 <td><strong>Dreaming / Reflection</strong></td>
-<td>✅ Coming next: offline Reflection across profiles, skills, and wiki</td>
-<td>❌ Usually online read/write APIs rather than file-native self-improvement</td>
+<td>✅ Coming next: offline Reflection that connects signals, compresses history, and improves profiles and skills between sessions</td>
+<td>❌ Usually online read/write APIs, retrieval records, or summaries rather than offline memory consolidation</td>
 </tr>
 </table>
-
-<sub>✅ means first-class in the current or announced default posture. ❌ means it is usually absent or not the primary design center for that category. This is a product-shape comparison, not a claim that no individual project has an adjacent feature.</sub>
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 <br>
 
 - [EverOS 1.0.0 Highlights](#everos-100-highlights)
+- [Coming Next: Knowledge Wiki And Reflection](#coming-next-knowledge-wiki-and-reflection)
 - [Why EverOS](#why-everos)
 - [Quick Start](#quick-start)
 - [Architecture At A Glance](#architecture-at-a-glance)
@@ -49,7 +50,7 @@
 > through [EverAlgo](https://github.com/EverMind-AI/EverAlgo).
 >
 > **Watch this repository** for the next wave of memory-system work, including
-> Wiki-style knowledge layers and Dreaming for deeper offline evolution.
+> Knowledge Wiki and Dreaming / Reflection for deeper offline evolution.
 
 <table>
 <tr>
@@ -93,6 +94,41 @@ Search independently by <code>user_id</code>, <code>agent_id</code>,
 </td>
 </tr>
 </table>
+
+## Coming Next: Knowledge Wiki And Reflection
+
+Knowledge Wiki and Dreaming / Reflection are the next big EverOS features.
+They extend EverOS from long-term retrieval into an inspectable memory workspace
+that agents and humans can both improve.
+
+<table>
+<tr>
+<td width="50%" valign="top">
+<strong>Knowledge Wiki</strong><br>
+<br>
+Knowledge Wiki turns scattered episodes, files, facts, and agent traces into
+source-backed Markdown pages for people, projects, topics, decisions, and
+workflows. Instead of hiding memory behind vectors, EverOS will expose a
+wiki-like knowledge layer that users can read, correct, link, version, and open
+directly in their existing Markdown tools.
+</td>
+<td width="50%" valign="top">
+<strong>Dreaming / Reflection</strong><br>
+<br>
+Dreaming, exposed as Reflection, is the offline evolution loop. It revisits
+stored memory between active sessions, connects weak signals, compresses noisy
+history into durable patterns, updates profiles and skills, and prepares better
+future context. The goal is an agent that improves while you are away, not only
+while you are prompting it.
+</td>
+</tr>
+</table>
+
+Most memory systems stop at chat history, opaque profiles, or vector recall.
+EverOS differentiates itself by keeping memory local, Markdown-native,
+auditable, and self-evolving: raw memory stays readable, derived knowledge
+becomes a wiki, and offline Reflection turns repeated experience into more
+useful long-term behavior.
 
 <br>
 <div align="right">
@@ -665,9 +701,9 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 ## Watch EverOS
 
 EverOS 1.0.0 is the first release of a larger memory-system roadmap.
-Watch this repository for upcoming work on Wiki-style memory, Dreaming,
-deeper offline evolution, benchmark releases, and more real-world agent
-integrations.
+Watch this repository for upcoming work on Knowledge Wiki, Dreaming /
+Reflection, deeper offline evolution, benchmark releases, and more real-world
+agent integrations.
 
 If EverOS is useful to your agent stack, starring the repo helps more
 builders discover it.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 - [EverOS 1.0.0 Highlights](#everos-100-highlights)
 - [Why EverOS](#why-everos)
+- [How EverOS Is Different](#how-everos-is-different)
 - [Quick Start](#quick-start)
 - [Architecture At A Glance](#architecture-at-a-glance)
 - [Storage Layout](#storage-layout)
@@ -122,6 +123,60 @@ The system is built around three boundaries:
 1. **Memory content stays readable** - Markdown is the durable source of truth.
 2. **Runtime state stays local** - SQLite tracks state and LanceDB handles vector, BM25, and scalar-filter search.
 3. **Algorithms stay modular** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) owns memory algorithms; EverOS owns runtime, persistence, online flows, and offline evolution.
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+
+## How EverOS Is Different
+
+Most memory libraries are useful, but many optimize for managed APIs, vector or
+graph recall, or one narrow memory surface. EverOS is built as a local,
+inspectable memory workspace for both agents and people.
+
+<table>
+<tr>
+<th width="24%">Developer need</th>
+<th width="38%">EverOS</th>
+<th width="38%">Common memory-library default</th>
+</tr>
+<tr>
+<td><strong>Readable source of truth</strong></td>
+<td>✅ Markdown files are the canonical memory surface. Open them in Obsidian, review diffs, or version them with Git.</td>
+<td>❌ Memory usually lives behind APIs, dashboards, vector stores, graphs, or backend payloads.</td>
+</tr>
+<tr>
+<td><strong>Simple local runtime</strong></td>
+<td>✅ Markdown + SQLite + LanceDB keep content, state, BM25, vectors, and scalar filters local.</td>
+<td>❌ Many systems center on managed services, vector DBs, graph DBs, or pluggable backend services.</td>
+</tr>
+<tr>
+<td><strong>Human-editable memory</strong></td>
+<td>✅ Edit a <code>.md</code> file directly; the cascade watcher diffs entries and syncs derived indexes.</td>
+<td>❌ Memory updates usually go through an SDK, API, dashboard, or storage backend.</td>
+</tr>
+<tr>
+<td><strong>User and agent tracks</strong></td>
+<td>✅ User memory (<code>episodes</code> / <code>profile</code>) and agent memory (<code>cases</code> / <code>skills</code>) are first-class.</td>
+<td>❌ Most systems focus on chat history, profiles, graph facts, or retrieval records rather than both tracks.</td>
+</tr>
+<tr>
+<td><strong>Portable scopes</strong></td>
+<td>✅ Search orthogonally by <code>user_id</code>, <code>agent_id</code>, <code>app_id</code>, <code>project_id</code>, and <code>session_id</code>.</td>
+<td>❌ Scope is often centered on one app, thread, tenant, or custom schema.</td>
+</tr>
+<tr>
+<td><strong>Auditable evolution</strong></td>
+<td>✅ Repeated experience becomes reusable skills while raw memory remains editable Markdown; Knowledge Wiki and Reflection keep evolution inspectable.</td>
+<td>❌ Evolution, when available, usually happens inside service state, graphs, or dashboards rather than editable source files.</td>
+</tr>
+</table>
+
+<sub>Comparison is about default product posture across public memory-library repos, not every optional backend or deployment mode.</sub>
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 <br>
 
-- [EverOS 1.0.0 Highlights](#everos-100-highlights)
+- [EverOS 1.0.0](#everos-100)
 - [Why EverOS](#why-everos)
 - [How EverOS Is Different](#how-everos-is-different)
 - [Quick Start](#quick-start)
@@ -40,7 +40,7 @@
 </details>
 
 
-## EverOS 1.0.0 Highlights
+## EverOS 1.0.0
 
 > [!IMPORTANT]
 >
@@ -53,49 +53,6 @@
 > source-backed Markdown knowledge pages. Reflection, also called Dreaming,
 > will run offline to connect signals, compress history, and improve profiles
 > and skills between sessions.
-
-<table>
-<tr>
-<td width="33%" valign="top">
-<strong>Markdown As Source Of Truth</strong><br>
-<br>
-All memory is persisted as <code>.md</code> files: readable, editable,
-grep-able, Git-versioned, and openable directly in Obsidian.
-</td>
-<td width="33%" valign="top">
-<strong>Local Three-Part Stack</strong><br>
-<br>
-Markdown + SQLite + LanceDB keep vectors, BM25, and scalar filters
-local. No MongoDB, Elasticsearch, or Redis required.
-</td>
-<td width="33%" valign="top">
-<strong>Dual-Track Memory</strong><br>
-<br>
-Agent memory (<code>cases</code> / <code>skills</code>) and user memory
-(<code>episodes</code> / <code>profile</code>) are extracted independently.
-</td>
-</tr>
-<tr>
-<td width="33%" valign="top">
-<strong>Multimodal Ingestion</strong><br>
-<br>
-Text, images, audio, documents, PDFs, HTML, and email are unified into
-searchable memory.
-</td>
-<td width="33%" valign="top">
-<strong>Self-Evolution</strong><br>
-<br>
-Common skills are extracted from real usage; repeated patterns become
-reusable workflows, no retraining required.
-</td>
-<td width="33%" valign="top">
-<strong>Orthogonal Retrieval</strong><br>
-<br>
-Search independently by <code>user_id</code>, <code>agent_id</code>,
-<code>app_id</code>, <code>project_id</code>, and <code>session_id</code>.
-</td>
-</tr>
-</table>
 
 <br>
 <div align="right">
@@ -177,14 +134,20 @@ the canonical memory layer, not just an export, log, or integration target.
 <td>❌ Usually folder, project, or conversation scoped</td>
 </tr>
 <tr>
-<td><strong>Markdown-native evolution</strong><br><sub>Skills, upcoming Knowledge Wiki, and Reflection evolve from inspectable source files.</sub></td>
-<td>✅ Built around files</td>
-<td>❌ If evolution exists, it usually lives in service, graph, or database state</td>
-<td>❌ Usually recall-oriented rather than file-native self-evolution</td>
+<td><strong>Knowledge Wiki</strong><br><sub>Memory should become editable, source-backed knowledge pages.</sub></td>
+<td>✅ Coming next: Markdown wiki pages derived from memory</td>
+<td>❌ Usually retrieval, graph, dashboard, or generated summary state</td>
+<td>✅ Often wiki-like, but usually manual or separate from runtime memory</td>
+</tr>
+<tr>
+<td><strong>Dreaming / Reflection</strong><br><sub>Offline consolidation should connect signals and improve long-term behavior.</sub></td>
+<td>✅ Coming next: offline Reflection across profiles, skills, and wiki</td>
+<td>❌ Usually online read/write APIs rather than file-native self-improvement</td>
+<td>❌ Usually note recall or summaries, not runtime memory evolution</td>
 </tr>
 </table>
 
-<sub>✅ means first-class in the default posture. ❌ means it is usually absent or not the primary design center for that category. This is a product-shape comparison, not a claim that no individual project has an adjacent feature.</sub>
+<sub>✅ means first-class in the current or announced default posture. ❌ means it is usually absent or not the primary design center for that category. This is a product-shape comparison, not a claim that no individual project has an adjacent feature.</sub>
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -134,49 +134,77 @@ The system is built around three boundaries:
 
 ## How EverOS Is Different
 
-Most memory libraries are useful, but many optimize for managed APIs, vector or
-graph recall, or one narrow memory surface. EverOS is built as a local,
-inspectable memory workspace for both agents and people.
+The table below compares first-class, developer-visible capabilities from
+public memory-library repos and docs. It focuses on default product posture,
+not every optional backend or enterprise deployment.
 
 <table>
 <tr>
-<th width="24%">Developer need</th>
-<th width="38%">EverOS</th>
-<th width="38%">Common memory-library default</th>
+<th width="22%">Capability</th>
+<th width="13%">EverOS</th>
+<th width="13%">Mem0</th>
+<th width="13%">MemOS</th>
+<th width="13%">MemPalace</th>
+<th width="13%">MemoryLake</th>
+<th width="13%">LangMem / Cognee / Graphiti</th>
 </tr>
 <tr>
-<td><strong>Readable source of truth</strong></td>
-<td>✅ Markdown files are the canonical memory surface. Open them in Obsidian, review diffs, or version them with Git.</td>
-<td>❌ Memory usually lives behind APIs, dashboards, vector stores, graphs, or backend payloads.</td>
+<td><strong>Markdown source of truth</strong><br><sub>Memory is readable, editable, diffable, and Git-versioned as files.</sub></td>
+<td>✅ Canonical <code>.md</code> memory</td>
+<td>❌ API / backend memory</td>
+<td>❌ Memory cubes / service state</td>
+<td>❌ Verbatim store + backend index</td>
+<td>❌ Hosted memory passport</td>
+<td>❌ Store / graph / platform state</td>
 </tr>
 <tr>
-<td><strong>Simple local runtime</strong></td>
-<td>✅ Markdown + SQLite + LanceDB keep content, state, BM25, vectors, and scalar filters local.</td>
-<td>❌ Many systems center on managed services, vector DBs, graph DBs, or pluggable backend services.</td>
+<td><strong>Direct file editing</strong><br><sub>Edit memory with normal developer tools, then sync indexes.</sub></td>
+<td>✅ Edit <code>.md</code> files; cascade watcher syncs</td>
+<td>❌ SDK / API path</td>
+<td>❌ API / dashboard path</td>
+<td>❌ CLI / backend path</td>
+<td>❌ App / API path</td>
+<td>❌ Store / graph API path</td>
 </tr>
 <tr>
-<td><strong>Human-editable memory</strong></td>
-<td>✅ Edit a <code>.md</code> file directly; the cascade watcher diffs entries and syncs derived indexes.</td>
-<td>❌ Memory updates usually go through an SDK, API, dashboard, or storage backend.</td>
+<td><strong>Local three-part stack</strong><br><sub>Markdown + SQLite + LanceDB; no MongoDB, Elasticsearch, or Redis required.</sub></td>
+<td>✅ Built in</td>
+<td>❌ Vector / service stack</td>
+<td>❌ Cloud or self-hosted service stack</td>
+<td>❌ Chroma / pluggable backend stack</td>
+<td>❌ Hosted product stack</td>
+<td>❌ Graph / database / platform stack</td>
 </tr>
 <tr>
-<td><strong>User and agent tracks</strong></td>
-<td>✅ User memory (<code>episodes</code> / <code>profile</code>) and agent memory (<code>cases</code> / <code>skills</code>) are first-class.</td>
-<td>❌ Most systems focus on chat history, profiles, graph facts, or retrieval records rather than both tracks.</td>
+<td><strong>User + agent memory tracks</strong><br><sub>User <code>episodes/profile</code> and agent <code>cases/skills</code> are separate first-class surfaces.</sub></td>
+<td>✅ Built in</td>
+<td>❌ User/session/agent state, not this dual track</td>
+<td>❌ Multi-layer memory, not this dual track</td>
+<td>❌ Conversation/project recall focus</td>
+<td>❌ Personal memory passport focus</td>
+<td>❌ App memory or graph focus</td>
 </tr>
 <tr>
-<td><strong>Portable scopes</strong></td>
-<td>✅ Search orthogonally by <code>user_id</code>, <code>agent_id</code>, <code>app_id</code>, <code>project_id</code>, and <code>session_id</code>.</td>
-<td>❌ Scope is often centered on one app, thread, tenant, or custom schema.</td>
+<td><strong>Orthogonal retrieval scopes</strong><br><sub>Search by <code>user_id</code>, <code>agent_id</code>, <code>app_id</code>, <code>project_id</code>, and <code>session_id</code>.</sub></td>
+<td>✅ Built in</td>
+<td>❌ Different scoping model</td>
+<td>❌ Different scoping model</td>
+<td>❌ Wing / room style scoping</td>
+<td>❌ Product account / connector scoping</td>
+<td>❌ Namespace / graph / app scoping</td>
 </tr>
 <tr>
-<td><strong>Auditable evolution</strong></td>
-<td>✅ Repeated experience becomes reusable skills while raw memory remains editable Markdown; Knowledge Wiki and Reflection keep evolution inspectable.</td>
-<td>❌ Evolution, when available, usually happens inside service state, graphs, or dashboards rather than editable source files.</td>
+<td><strong>Markdown-native evolution</strong><br><sub>Skills, upcoming Knowledge Wiki, and Reflection evolve from inspectable source files.</sub></td>
+<td>✅ Built around files</td>
+<td>❌ Evolution is not Markdown-native</td>
+<td>❌ Evolution is not Markdown-native</td>
+<td>❌ Retrieval-first, no Markdown-native evolution</td>
+<td>❌ Reflection is product state, not Markdown-native</td>
+<td>❌ Evolution lives in stores or graphs</td>
 </tr>
 </table>
 
-<sub>Comparison is about default product posture across public memory-library repos, not every optional backend or deployment mode.</sub>
+<sub>✅ = first-class/default in public docs. ❌ = not presented as a first-class/default capability in public docs. Mem0 is sometimes referred to as MemZero; MemoryLake covers the MemLake shorthand.</sub>
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 <br>
 
 - [EverOS 1.0.0](#everos-100)
-- [EverMe: One Memory For All](#everme-one-memory-for-all)
-- [How EverMe Is Different](#how-everme-is-different)
+- [EverOS: One Memory For All](#everos-one-memory-for-all)
+- [How EverOS Is Different](#how-everos-is-different)
 - [Quick Start](#quick-start)
 - [Architecture At A Glance](#architecture-at-a-glance)
 - [Storage Layout](#storage-layout)
@@ -62,7 +62,7 @@
 </div>
 
 
-## EverMe: One Memory For All
+## EverOS: One Memory For All
 
 <table>
 <tr>
@@ -107,11 +107,11 @@ Search independently by <code>user_id</code>, <code>agent_id</code>,
 </tr>
 </table>
 
-EverMe is the personal-memory experience built on EverOS: a CLI and agent
-plugin layer that lets one memory follow a maker across coding assistants,
-apps, devices, and workflows. Today it stores conversations, files, and agent
-trajectories as readable Markdown, then syncs local SQLite and LanceDB indexes
-for fast retrieval and self-evolving reuse.
+EverOS is the local memory operating system for agents and makers. It gives
+one portable memory layer across coding assistants, apps, devices, and
+workflows. Today it stores conversations, files, and agent trajectories as
+readable Markdown, then syncs local SQLite and LanceDB indexes for fast
+retrieval and self-evolving reuse.
 
 <br>
 <div align="right">
@@ -121,17 +121,17 @@ for fast retrieval and self-evolving reuse.
 </div>
 
 
-## How EverMe Is Different
+## How EverOS Is Different
 
 The table below compares common memory-library architectures rather than naming
 specific repos. Some projects overlap categories, and some do expose
-file-oriented or Markdown-like surfaces. EverMe is different because Markdown is
+file-oriented or Markdown-like surfaces. EverOS is different because Markdown is
 the canonical memory layer, not just an export, log, or integration target.
 
 <table>
 <tr>
 <th width="28%">Title</th>
-<th width="36%">EverMe</th>
+<th width="36%">EverOS</th>
 <th width="36%">Agent Memory libraries</th>
 </tr>
 <tr>

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@
 >
 > **Coming next:** Knowledge Wiki will turn memory into editable,
 > source-backed Markdown knowledge pages. Reflection, also called Dreaming,
-> will run offline to connect signals, compress history, and improve profiles
-> and skills between sessions.
+> will run when the system is idle or offline to connect signals, compress
+> history, and improve profiles and skills between sessions.
 
 <br>
 <div align="right">
@@ -63,6 +63,12 @@
 
 
 ## EverOS: One Memory For All
+
+EverOS is the local memory operating system for agents and makers. It gives
+one portable memory layer across coding assistants, apps, devices, and
+workflows. Today it stores conversations, files, and agent trajectories as
+readable Markdown, then syncs local SQLite and LanceDB indexes for fast
+retrieval and self-evolving reuse.
 
 <table>
 <tr>
@@ -106,12 +112,6 @@ Search independently by <code>user_id</code>, <code>agent_id</code>,
 </td>
 </tr>
 </table>
-
-EverOS is the local memory operating system for agents and makers. It gives
-one portable memory layer across coding assistants, apps, devices, and
-workflows. Today it stores conversations, files, and agent trajectories as
-readable Markdown, then syncs local SQLite and LanceDB indexes for fast
-retrieval and self-evolving reuse.
 
 <br>
 <div align="right">
@@ -161,8 +161,8 @@ retrieval and self-evolving reuse.
 </tr>
 <tr>
 <td><strong>Dreaming / Reflection</strong></td>
-<td>✅ Coming next: offline Reflection that connects signals, compresses history, and improves profiles and skills between sessions</td>
-<td>❌ Usually online read/write APIs, retrieval records, or summaries rather than offline memory consolidation</td>
+<td>✅ Coming next: Reflection that runs when the system is idle or offline to connect signals, compress history, and improve profiles and skills between sessions</td>
+<td>❌ Usually online read/write APIs, retrieval records, or summaries rather than idle-time memory consolidation</td>
 </tr>
 </table>
 
@@ -710,8 +710,8 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 ## Watch EverOS
 
 EverOS 1.0.0 is the first release of a larger memory-system roadmap.
-Watch this repository for upcoming work on deeper offline evolution, benchmark
-releases, and more real-world agent integrations.
+Watch this repository for upcoming work on deeper idle-time and offline evolution,
+benchmark releases, and more real-world agent integrations.
 
 <table>
 <tr>
@@ -726,9 +726,10 @@ existing Markdown tools.
 <td width="50%" valign="top">
 <strong>Dreaming / Reflection</strong><br>
 <br>
-Runs offline between active sessions to revisit stored memory, connect weak
+Runs when the system is idle or offline to revisit stored memory, connect weak
 signals, compress noisy history into durable patterns, and improve profiles and
-skills. The agent gets better while you are away, not only while you prompt it.
+skills. The agent gets better between active sessions, not only while you prompt
+it.
 </td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -134,77 +134,57 @@ The system is built around three boundaries:
 
 ## How EverOS Is Different
 
-The table below compares first-class, developer-visible capabilities from
-public memory-library repos and docs. It focuses on default product posture,
-not every optional backend or enterprise deployment.
+The table below compares common memory-library architectures rather than naming
+specific repos. Some projects overlap categories, and some do expose
+file-oriented or Markdown-like surfaces. EverOS is different because Markdown is
+the canonical memory layer, not just an export, log, or integration target.
 
 <table>
 <tr>
-<th width="22%">Capability</th>
-<th width="13%">EverOS</th>
-<th width="13%">Mem0</th>
-<th width="13%">MemOS</th>
-<th width="13%">MemPalace</th>
-<th width="13%">MemoryLake</th>
-<th width="13%">LangMem / Cognee / Graphiti</th>
+<th width="24%">Developer need</th>
+<th width="28%">EverOS default</th>
+<th width="24%">Typical memory libraries</th>
+<th width="24%">File / Markdown-adjacent tools</th>
 </tr>
 <tr>
 <td><strong>Markdown source of truth</strong><br><sub>Memory is readable, editable, diffable, and Git-versioned as files.</sub></td>
 <td>✅ Canonical <code>.md</code> memory</td>
-<td>❌ API / backend memory</td>
-<td>❌ Memory cubes / service state</td>
-<td>❌ Verbatim store + backend index</td>
-<td>❌ Hosted memory passport</td>
-<td>❌ Store / graph / platform state</td>
+<td>❌ Usually API, vector, graph, dashboard, or database state</td>
+<td>✅ Often readable, but not always the full runtime source of truth</td>
 </tr>
 <tr>
 <td><strong>Direct file editing</strong><br><sub>Edit memory with normal developer tools, then sync indexes.</sub></td>
 <td>✅ Edit <code>.md</code> files; cascade watcher syncs</td>
-<td>❌ SDK / API path</td>
-<td>❌ API / dashboard path</td>
-<td>❌ CLI / backend path</td>
-<td>❌ App / API path</td>
-<td>❌ Store / graph API path</td>
+<td>❌ Usually SDK, API, dashboard, or backend update paths</td>
+<td>✅ Sometimes possible, but often without entry-level index sync</td>
 </tr>
 <tr>
 <td><strong>Local three-part stack</strong><br><sub>Markdown + SQLite + LanceDB; no MongoDB, Elasticsearch, or Redis required.</sub></td>
 <td>✅ Built in</td>
-<td>❌ Vector / service stack</td>
-<td>❌ Cloud or self-hosted service stack</td>
-<td>❌ Chroma / pluggable backend stack</td>
-<td>❌ Hosted product stack</td>
-<td>❌ Graph / database / platform stack</td>
+<td>❌ Often depends on managed services, vector DBs, graph DBs, or server stacks</td>
+<td>❌ Often local, but commonly tied to a different index/backend model</td>
 </tr>
 <tr>
 <td><strong>User + agent memory tracks</strong><br><sub>User <code>episodes/profile</code> and agent <code>cases/skills</code> are separate first-class surfaces.</sub></td>
 <td>✅ Built in</td>
-<td>❌ User/session/agent state, not this dual track</td>
-<td>❌ Multi-layer memory, not this dual track</td>
-<td>❌ Conversation/project recall focus</td>
-<td>❌ Personal memory passport focus</td>
-<td>❌ App memory or graph focus</td>
+<td>❌ Usually centered on chat history, profiles, entities, facts, or retrieval records</td>
+<td>❌ Usually centered on logs, notes, projects, or conversations</td>
 </tr>
 <tr>
 <td><strong>Orthogonal retrieval scopes</strong><br><sub>Search by <code>user_id</code>, <code>agent_id</code>, <code>app_id</code>, <code>project_id</code>, and <code>session_id</code>.</sub></td>
 <td>✅ Built in</td>
-<td>❌ Different scoping model</td>
-<td>❌ Different scoping model</td>
-<td>❌ Wing / room style scoping</td>
-<td>❌ Product account / connector scoping</td>
-<td>❌ Namespace / graph / app scoping</td>
+<td>❌ Usually app, namespace, tenant, thread, or graph scoped</td>
+<td>❌ Usually folder, project, or conversation scoped</td>
 </tr>
 <tr>
 <td><strong>Markdown-native evolution</strong><br><sub>Skills, upcoming Knowledge Wiki, and Reflection evolve from inspectable source files.</sub></td>
 <td>✅ Built around files</td>
-<td>❌ Evolution is not Markdown-native</td>
-<td>❌ Evolution is not Markdown-native</td>
-<td>❌ Retrieval-first, no Markdown-native evolution</td>
-<td>❌ Reflection is product state, not Markdown-native</td>
-<td>❌ Evolution lives in stores or graphs</td>
+<td>❌ If evolution exists, it usually lives in service, graph, or database state</td>
+<td>❌ Usually recall-oriented rather than file-native self-evolution</td>
 </tr>
 </table>
 
-<sub>✅ = first-class/default in public docs. ❌ = not presented as a first-class/default capability in public docs. Mem0 is sometimes referred to as MemZero; MemoryLake covers the MemLake shorthand.</sub>
+<sub>✅ means first-class in the default posture. ❌ means it is usually absent or not the primary design center for that category. This is a product-shape comparison, not a claim that no individual project has an adjacent feature.</sub>
 
 <br>
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 <br>
 
 - [EverOS 1.0.0 Highlights](#everos-100-highlights)
-- [Coming Next: Knowledge Wiki And Reflection](#coming-next-knowledge-wiki-and-reflection)
 - [Why EverOS](#why-everos)
 - [Quick Start](#quick-start)
 - [Architecture At A Glance](#architecture-at-a-glance)
@@ -49,8 +48,10 @@
 > multimodal ingestion, user and agent memory scopes, and modular algorithms
 > through [EverAlgo](https://github.com/EverMind-AI/EverAlgo).
 >
-> **Watch this repository** for the next wave of memory-system work, including
-> Knowledge Wiki and Dreaming / Reflection for deeper offline evolution.
+> **Coming next:** Knowledge Wiki will turn memory into editable,
+> source-backed Markdown knowledge pages. Reflection, also called Dreaming,
+> will run offline to connect signals, compress history, and improve profiles
+> and skills between sessions.
 
 <table>
 <tr>
@@ -94,41 +95,6 @@ Search independently by <code>user_id</code>, <code>agent_id</code>,
 </td>
 </tr>
 </table>
-
-## Coming Next: Knowledge Wiki And Reflection
-
-Knowledge Wiki and Dreaming / Reflection are the next big EverOS features.
-They extend EverOS from long-term retrieval into an inspectable memory workspace
-that agents and humans can both improve.
-
-<table>
-<tr>
-<td width="50%" valign="top">
-<strong>Knowledge Wiki</strong><br>
-<br>
-Knowledge Wiki turns scattered episodes, files, facts, and agent traces into
-source-backed Markdown pages for people, projects, topics, decisions, and
-workflows. Instead of hiding memory behind vectors, EverOS will expose a
-wiki-like knowledge layer that users can read, correct, link, version, and open
-directly in their existing Markdown tools.
-</td>
-<td width="50%" valign="top">
-<strong>Dreaming / Reflection</strong><br>
-<br>
-Dreaming, exposed as Reflection, is the offline evolution loop. It revisits
-stored memory between active sessions, connects weak signals, compresses noisy
-history into durable patterns, updates profiles and skills, and prepares better
-future context. The goal is an agent that improves while you are away, not only
-while you are prompting it.
-</td>
-</tr>
-</table>
-
-Most memory systems stop at chat history, opaque profiles, or vector recall.
-EverOS differentiates itself by keeping memory local, Markdown-native,
-auditable, and self-evolving: raw memory stays readable, derived knowledge
-becomes a wiki, and offline Reflection turns repeated experience into more
-useful long-term behavior.
 
 <br>
 <div align="right">
@@ -701,9 +667,33 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 ## Watch EverOS
 
 EverOS 1.0.0 is the first release of a larger memory-system roadmap.
-Watch this repository for upcoming work on Knowledge Wiki, Dreaming /
-Reflection, deeper offline evolution, benchmark releases, and more real-world
-agent integrations.
+Watch this repository for upcoming work on deeper offline evolution, benchmark
+releases, and more real-world agent integrations.
+
+<table>
+<tr>
+<td width="50%" valign="top">
+<strong>Knowledge Wiki</strong><br>
+<br>
+Turns scattered episodes, files, facts, and agent traces into source-backed
+Markdown pages for people, projects, topics, decisions, and workflows. Memory
+becomes something users can read, correct, link, version, and open in their
+existing Markdown tools.
+</td>
+<td width="50%" valign="top">
+<strong>Dreaming / Reflection</strong><br>
+<br>
+Runs offline between active sessions to revisit stored memory, connect weak
+signals, compress noisy history into durable patterns, and improve profiles and
+skills. The agent gets better while you are away, not only while you prompt it.
+</td>
+</tr>
+</table>
+
+Most memory systems stop at chat history, opaque profiles, or vector recall.
+EverOS keeps memory local, Markdown-native, auditable, and self-evolving: raw
+memory stays readable, derived knowledge becomes a wiki, and Reflection turns
+repeated experience into more useful long-term behavior.
 
 If EverOS is useful to your agent stack, starring the repo helps more
 builders discover it.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,8 +50,8 @@
 > [EverAlgo](https://github.com/EverMind-AI/EverAlgo) 支撑的模块化算法。
 >
 > **即将推出：** Knowledge Wiki 会把记忆整理成可编辑、可溯源的
-> Markdown 知识页。Reflection（也称 Dreaming）会在离线时连接信号、
-> 压缩历史，并持续改进 profile 和 skills。
+> Markdown 知识页。Reflection（也称 Dreaming）会在系统空闲或离线时
+> 连接信号、压缩历史，并持续改进 profile 和 skills。
 
 <br>
 <div align="right">
@@ -62,6 +62,11 @@
 
 
 ## EverOS: One Memory For All
+
+EverOS 是面向 agents 和 makers 的本地记忆操作系统。它提供一层可携带的
+统一记忆层，让记忆穿过 coding assistants、apps、devices 和 workflows。
+目前它会把对话、文件和 Agent 轨迹保存为可读 Markdown，并同步本地 SQLite
+和 LanceDB 索引，用于快速检索和自进化复用。
 
 <table>
 <tr>
@@ -99,11 +104,6 @@ Agent 记忆（<code>cases</code> / <code>skills</code>）与用户记忆（<cod
 </td>
 </tr>
 </table>
-
-EverOS 是面向 agents 和 makers 的本地记忆操作系统。它提供一层可携带的
-统一记忆层，让记忆穿过 coding assistants、apps、devices 和 workflows。
-目前它会把对话、文件和 Agent 轨迹保存为可读 Markdown，并同步本地 SQLite
-和 LanceDB 索引，用于快速检索和自进化复用。
 
 <br>
 <div align="right">
@@ -153,8 +153,8 @@ EverOS 是面向 agents 和 makers 的本地记忆操作系统。它提供一层
 </tr>
 <tr>
 <td><strong>Dreaming / Reflection</strong></td>
-<td>✅ 即将推出：离线连接信号、压缩历史，并在 session 之间改进 profiles 和 skills</td>
-<td>❌ 通常是在线读写 API、retrieval records 或 summaries，而不是离线记忆整理</td>
+<td>✅ 即将推出：在系统空闲或离线时运行，用来连接信号、压缩历史，并在 session 之间改进 profiles 和 skills</td>
+<td>❌ 通常是在线读写 API、retrieval records 或 summaries，而不是空闲态记忆整理</td>
 </tr>
 </table>
 
@@ -696,7 +696,7 @@ Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 
 ## 关注 EverOS
 
 EverOS 1.0.0 是更大规模记忆系统路线图的第一个发布版本。Watch 这个仓库，
-即可持续关注更深入的离线进化、benchmark releases，以及更多真实 Agent 集成。
+即可持续关注更深入的空闲态和离线进化、benchmark releases，以及更多真实 Agent 集成。
 
 <table>
 <tr>
@@ -710,8 +710,8 @@ EverOS 1.0.0 是更大规模记忆系统路线图的第一个发布版本。Watc
 <td width="50%" valign="top">
 <strong>Dreaming / Reflection</strong><br>
 <br>
-在活跃会话之间离线运行，重新审视已存储记忆，连接弱信号，把嘈杂历史压缩成稳定模式，
-并持续改进 profile 和 skills。目标是让 Agent 在你离开时也能变得更好，
+在系统空闲或离线时运行，重新审视已存储记忆，连接弱信号，把嘈杂历史压缩成稳定模式，
+并持续改进 profile 和 skills。目标是让 Agent 在活跃 session 之间也能变得更好，
 而不是只在你 prompt 它时才进步。
 </td>
 </tr>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@
 <br>
 
 - [EverOS 1.0.0](#everos-100)
-- [EverMe: One Memory For All](#everme-one-memory-for-all)
-- [EverMe 的差异](#everme-的差异)
+- [EverOS: One Memory For All](#everos-one-memory-for-all)
+- [EverOS 的差异](#everos-的差异)
 - [快速开始](#快速开始)
 - [架构概览](#架构概览)
 - [存储布局](#存储布局)
@@ -61,7 +61,7 @@
 </div>
 
 
-## EverMe: One Memory For All
+## EverOS: One Memory For All
 
 <table>
 <tr>
@@ -100,8 +100,8 @@ Agent 记忆（<code>cases</code> / <code>skills</code>）与用户记忆（<cod
 </tr>
 </table>
 
-EverMe 是构建在 EverOS 之上的个人记忆体验：通过 CLI 和 Agent plugin layer，
-让同一份记忆跟随 maker 穿过 coding assistants、apps、devices 和 workflows。
+EverOS 是面向 agents 和 makers 的本地记忆操作系统。它提供一层可携带的
+统一记忆层，让记忆穿过 coding assistants、apps、devices 和 workflows。
 目前它会把对话、文件和 Agent 轨迹保存为可读 Markdown，并同步本地 SQLite
 和 LanceDB 索引，用于快速检索和自进化复用。
 
@@ -113,16 +113,16 @@ EverMe 是构建在 EverOS 之上的个人记忆体验：通过 CLI 和 Agent pl
 </div>
 
 
-## EverMe 的差异
+## EverOS 的差异
 
 下面这张表比较的是常见 memory-library 架构类型，而不是点名具体仓库。
 有些项目会跨多个类型，也确实有项目提供 file-oriented 或 Markdown-like 能力。
-EverMe 的差异在于：Markdown 是标准记忆层，而不是 export、log 或 integration target。
+EverOS 的差异在于：Markdown 是标准记忆层，而不是 export、log 或 integration target。
 
 <table>
 <tr>
 <th width="28%">Title</th>
-<th width="36%">EverMe</th>
+<th width="36%">EverOS</th>
 <th width="36%">Agent Memory libraries</th>
 </tr>
 <tr>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@
 <br>
 
 - [EverOS 1.0.0](#everos-100)
-- [为什么选择 EverOS](#为什么选择-everos)
-- [EverOS 的差异](#everos-的差异)
+- [EverMe: One Memory For All](#everme-one-memory-for-all)
+- [EverMe 的差异](#everme-的差异)
 - [快速开始](#快速开始)
 - [架构概览](#架构概览)
 - [存储布局](#存储布局)
@@ -61,22 +61,49 @@
 </div>
 
 
-## 为什么选择 EverOS
+## EverMe: One Memory For All
 
-EverOS 是一个开源 Python 框架，用来构建**跨 Agent、跨平台的自进化长期记忆**。
-它为 maker 提供一层可携带的统一记忆层，适用于他们使用的每一个 Agent：
-Claude Code、Codex、OpenClaw、Hermes 等等。这样，上下文、决策、文件和
-Agent 轨迹可以跟着工作流走，而不是被锁在某一个工具里。
+<table>
+<tr>
+<td width="33%" valign="top">
+<strong>Markdown As Source Of Truth</strong><br>
+<br>
+所有记忆持久化为 <code>.md</code> 文件：可读、可改、可 grep、可 Git 版本化，也可直接用 Obsidian 打开。
+</td>
+<td width="33%" valign="top">
+<strong>Local Three-Part Stack</strong><br>
+<br>
+Markdown + SQLite + LanceDB 在本地完成向量、BM25 和标量过滤检索，无需 MongoDB、Elasticsearch 或 Redis。
+</td>
+<td width="33%" valign="top">
+<strong>Dual-Track Memory</strong><br>
+<br>
+Agent 记忆（<code>cases</code> / <code>skills</code>）与用户记忆（<code>episodes</code> / <code>profile</code>）独立提取，互不污染。
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+<strong>Multimodal Ingestion</strong><br>
+<br>
+文本、图像、音频、文档、PDF、HTML 和邮件统一抽取为可检索的记忆形态。
+</td>
+<td width="33%" valign="top">
+<strong>Self-Evolution</strong><br>
+<br>
+从真实使用经验中自动抽取共性 skills，重复模式沉淀为可复用流程，无需重训。
+</td>
+<td width="33%" valign="top">
+<strong>Orthogonal Retrieval</strong><br>
+<br>
+按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 五维独立检索。
+</td>
+</tr>
+</table>
 
-EverOS 会把对话、Agent 轨迹和文件保存为可读 Markdown，并同步本地 SQLite
-和 LanceDB 索引，以便快速检索。Agent 可以复用过去的 cases 和 skills，从重复
-工作流中自我改进，并逐渐变得更加主动。
-
-系统围绕三个边界设计：
-
-1. **记忆内容保持可读** - Markdown 是长期、耐用的 source of truth。
-2. **运行时状态保持本地** - SQLite 跟踪状态；LanceDB 处理向量、BM25 和结构化过滤搜索。
-3. **算法保持模块化** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) 负责记忆算法；EverOS 负责运行时、持久化、在线流程和离线进化。
+EverMe 是构建在 EverOS 之上的个人记忆体验：通过 CLI 和 Agent plugin layer，
+让同一份记忆跟随 maker 穿过 coding assistants、apps、devices 和 workflows。
+目前它会把对话、文件和 Agent 轨迹保存为可读 Markdown，并同步本地 SQLite
+和 LanceDB 索引，用于快速检索和自进化复用。
 
 <br>
 <div align="right">
@@ -86,60 +113,52 @@ EverOS 会把对话、Agent 轨迹和文件保存为可读 Markdown，并同步�
 </div>
 
 
-## EverOS 的差异
+## EverMe 的差异
 
 下面这张表比较的是常见 memory-library 架构类型，而不是点名具体仓库。
 有些项目会跨多个类型，也确实有项目提供 file-oriented 或 Markdown-like 能力。
-EverOS 的差异在于：Markdown 是标准记忆层，而不是 export、log 或 integration target。
+EverMe 的差异在于：Markdown 是标准记忆层，而不是 export、log 或 integration target。
 
 <table>
 <tr>
-<th width="24%">开发者关心什么</th>
-<th width="28%">EverOS default</th>
-<th width="24%">常见 memory libraries</th>
-<th width="24%">File / Markdown-adjacent tools</th>
+<th width="28%">Title</th>
+<th width="36%">EverMe</th>
+<th width="36%">Agent Memory libraries</th>
 </tr>
 <tr>
-<td><strong>Markdown source of truth</strong><br><sub>记忆以文件形式可读、可编辑、可 diff、可 Git 版本化。</sub></td>
-<td>✅ 标准 <code>.md</code> 记忆</td>
+<td><strong>Markdown source of truth</strong></td>
+<td>✅ 标准 <code>.md</code> 文件：可读、可编辑、可 diff、可 Git 版本化</td>
 <td>❌ 通常是 API、vector、graph、dashboard 或 database state</td>
-<td>✅ 往往可读，但不一定是完整 runtime source of truth</td>
 </tr>
 <tr>
-<td><strong>直接文件编辑</strong><br><sub>用普通开发者工具编辑记忆，然后同步索引。</sub></td>
+<td><strong>直接文件编辑</strong></td>
 <td>✅ 编辑 <code>.md</code>；cascade watcher 同步</td>
 <td>❌ 通常需要 SDK、API、dashboard 或 backend update path</td>
-<td>✅ 有些可以做到，但常常缺少 entry-level index sync</td>
 </tr>
 <tr>
-<td><strong>本地三件套</strong><br><sub>Markdown + SQLite + LanceDB；不需要 MongoDB、Elasticsearch 或 Redis。</sub></td>
-<td>✅ 内置</td>
+<td><strong>本地三件套</strong></td>
+<td>✅ Markdown + SQLite + LanceDB；不需要 MongoDB、Elasticsearch 或 Redis</td>
 <td>❌ 常依赖 managed service、vector DB、graph DB 或 server stack</td>
-<td>❌ 往往本地，但通常绑定另一套 index/backend model</td>
 </tr>
 <tr>
-<td><strong>用户 + Agent 双轨</strong><br><sub>用户 <code>episodes/profile</code> 与 Agent <code>cases/skills</code> 是分离的一等记忆表面。</sub></td>
-<td>✅ 内置</td>
+<td><strong>用户 + Agent 双轨</strong></td>
+<td>✅ 用户 <code>episodes/profile</code> 与 Agent <code>cases/skills</code> 是分离的一等记忆表面</td>
 <td>❌ 通常围绕 chat history、profiles、entities、facts 或 retrieval records</td>
-<td>❌ 通常围绕 logs、notes、projects 或 conversations</td>
 </tr>
 <tr>
-<td><strong>正交检索作用域</strong><br><sub>按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 检索。</sub></td>
-<td>✅ 内置</td>
+<td><strong>正交检索作用域</strong></td>
+<td>✅ 按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 检索</td>
 <td>❌ 通常按 app、namespace、tenant、thread 或 graph 来组织</td>
-<td>❌ 通常按 folder、project 或 conversation 来组织</td>
 </tr>
 <tr>
-<td><strong>Knowledge Wiki</strong><br><sub>记忆应该沉淀为可编辑、可溯源的知识页。</sub></td>
+<td><strong>Knowledge Wiki</strong></td>
 <td>✅ 即将推出：由记忆生成 Markdown wiki 知识页</td>
 <td>❌ 通常是 retrieval、graph、dashboard 或 generated summary state</td>
-<td>✅ 往往像 wiki，但通常是手写内容，或与 runtime memory 分离</td>
 </tr>
 <tr>
-<td><strong>Dreaming / Reflection</strong><br><sub>离线整理应该连接信号，并改善长期行为。</sub></td>
+<td><strong>Dreaming / Reflection</strong></td>
 <td>✅ 即将推出：围绕 profiles、skills 和 wiki 做离线 Reflection</td>
 <td>❌ 通常是在线读写 API，而不是基于文件的自我改进</td>
-<td>❌ 通常偏笔记召回或摘要，不是运行时记忆进化</td>
 </tr>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@
 
 - [EverOS 1.0.0 亮点](#everos-100-亮点)
 - [为什么选择 EverOS](#为什么选择-everos)
+- [EverOS 的差异](#everos-的差异)
 - [快速开始](#快速开始)
 - [架构概览](#架构概览)
 - [存储布局](#存储布局)
@@ -113,6 +114,60 @@ EverOS 会把对话、Agent 轨迹和文件保存为可读 Markdown，并同步�
 1. **记忆内容保持可读** - Markdown 是长期、耐用的 source of truth。
 2. **运行时状态保持本地** - SQLite 跟踪状态；LanceDB 处理向量、BM25 和结构化过滤搜索。
 3. **算法保持模块化** - [EverAlgo](https://github.com/EverMind-AI/EverAlgo) 负责记忆算法；EverOS 负责运行时、持久化、在线流程和离线进化。
+
+<br>
+<div align="right">
+
+[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
+
+</div>
+
+
+## EverOS 的差异
+
+许多 memory libraries 都有价值，但它们通常围绕 managed API、向量 / 图召回，
+或某一种单一记忆形态来设计。EverOS 的定位是一个面向 Agent 和人的本地、
+可检查记忆工作区。
+
+<table>
+<tr>
+<th width="24%">开发者关心什么</th>
+<th width="38%">EverOS</th>
+<th width="38%">常见 memory-library 默认形态</th>
+</tr>
+<tr>
+<td><strong>可读的 source of truth</strong></td>
+<td>✅ Markdown 文件就是标准记忆表面。可以用 Obsidian 打开、review diff，也可以用 Git 版本化。</td>
+<td>❌ 记忆通常藏在 API、dashboard、vector store、graph 或后端 payload 里。</td>
+</tr>
+<tr>
+<td><strong>简单本地运行时</strong></td>
+<td>✅ Markdown + SQLite + LanceDB 在本地保存内容、状态、BM25、向量和标量过滤。</td>
+<td>❌ 很多系统以 managed service、vector DB、graph DB 或可插拔后端服务为中心。</td>
+</tr>
+<tr>
+<td><strong>人可直接编辑</strong></td>
+<td>✅ 直接编辑 <code>.md</code> 文件；cascade watcher 会做 entry-level diff 并同步衍生索引。</td>
+<td>❌ 记忆更新通常需要经过 SDK、API、dashboard 或 storage backend。</td>
+</tr>
+<tr>
+<td><strong>用户与 Agent 双轨</strong></td>
+<td>✅ 用户记忆（<code>episodes</code> / <code>profile</code>）和 Agent 记忆（<code>cases</code> / <code>skills</code>）都是一等公民。</td>
+<td>❌ 多数系统更偏向 chat history、profile、graph facts 或 retrieval records，而不是同时覆盖两条轨道。</td>
+</tr>
+<tr>
+<td><strong>可携带的作用域</strong></td>
+<td>✅ 可按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 正交检索。</td>
+<td>❌ 作用域常常围绕单一 app、thread、tenant 或自定义 schema 展开。</td>
+</tr>
+<tr>
+<td><strong>可审计的进化</strong></td>
+<td>✅ 重复经验可以沉淀为 reusable skills，同时原始记忆仍是可编辑 Markdown；Knowledge Wiki 和 Reflection 会让进化过程保持可检查。</td>
+<td>❌ 即使支持 evolution，通常也发生在 service state、graph 或 dashboard 内，而不是可编辑源文件上。</td>
+</tr>
+</table>
+
+<sub>这里比较的是公开 memory-library repos 的默认产品取向，不代表每一种可选后端或部署模式。</sub>
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,49 +125,76 @@ EverOS 会把对话、Agent 轨迹和文件保存为可读 Markdown，并同步�
 
 ## EverOS 的差异
 
-许多 memory libraries 都有价值，但它们通常围绕 managed API、向量 / 图召回，
-或某一种单一记忆形态来设计。EverOS 的定位是一个面向 Agent 和人的本地、
-可检查记忆工作区。
+下面这张表对比的是公开 memory-library repos 和 docs 中的一等、默认、
+开发者可见能力。它比较的是产品默认取向，不覆盖每一种可选后端或企业部署模式。
 
 <table>
 <tr>
-<th width="24%">开发者关心什么</th>
-<th width="38%">EverOS</th>
-<th width="38%">常见 memory-library 默认形态</th>
+<th width="22%">能力</th>
+<th width="13%">EverOS</th>
+<th width="13%">Mem0</th>
+<th width="13%">MemOS</th>
+<th width="13%">MemPalace</th>
+<th width="13%">MemoryLake</th>
+<th width="13%">LangMem / Cognee / Graphiti</th>
 </tr>
 <tr>
-<td><strong>可读的 source of truth</strong></td>
-<td>✅ Markdown 文件就是标准记忆表面。可以用 Obsidian 打开、review diff，也可以用 Git 版本化。</td>
-<td>❌ 记忆通常藏在 API、dashboard、vector store、graph 或后端 payload 里。</td>
+<td><strong>Markdown source of truth</strong><br><sub>记忆以文件形式可读、可编辑、可 diff、可 Git 版本化。</sub></td>
+<td>✅ 标准 <code>.md</code> 记忆</td>
+<td>❌ API / backend memory</td>
+<td>❌ Memory cubes / service state</td>
+<td>❌ Verbatim store + backend index</td>
+<td>❌ Hosted memory passport</td>
+<td>❌ Store / graph / platform state</td>
 </tr>
 <tr>
-<td><strong>简单本地运行时</strong></td>
-<td>✅ Markdown + SQLite + LanceDB 在本地保存内容、状态、BM25、向量和标量过滤。</td>
-<td>❌ 很多系统以 managed service、vector DB、graph DB 或可插拔后端服务为中心。</td>
+<td><strong>直接文件编辑</strong><br><sub>用普通开发者工具编辑记忆，然后同步索引。</sub></td>
+<td>✅ 编辑 <code>.md</code>；cascade watcher 同步</td>
+<td>❌ SDK / API 路径</td>
+<td>❌ API / dashboard 路径</td>
+<td>❌ CLI / backend 路径</td>
+<td>❌ App / API 路径</td>
+<td>❌ Store / graph API 路径</td>
 </tr>
 <tr>
-<td><strong>人可直接编辑</strong></td>
-<td>✅ 直接编辑 <code>.md</code> 文件；cascade watcher 会做 entry-level diff 并同步衍生索引。</td>
-<td>❌ 记忆更新通常需要经过 SDK、API、dashboard 或 storage backend。</td>
+<td><strong>本地三件套</strong><br><sub>Markdown + SQLite + LanceDB；不需要 MongoDB、Elasticsearch 或 Redis。</sub></td>
+<td>✅ 内置</td>
+<td>❌ Vector / service stack</td>
+<td>❌ Cloud 或 self-hosted service stack</td>
+<td>❌ Chroma / pluggable backend stack</td>
+<td>❌ Hosted product stack</td>
+<td>❌ Graph / database / platform stack</td>
 </tr>
 <tr>
-<td><strong>用户与 Agent 双轨</strong></td>
-<td>✅ 用户记忆（<code>episodes</code> / <code>profile</code>）和 Agent 记忆（<code>cases</code> / <code>skills</code>）都是一等公民。</td>
-<td>❌ 多数系统更偏向 chat history、profile、graph facts 或 retrieval records，而不是同时覆盖两条轨道。</td>
+<td><strong>用户 + Agent 双轨</strong><br><sub>用户 <code>episodes/profile</code> 与 Agent <code>cases/skills</code> 是分离的一等记忆表面。</sub></td>
+<td>✅ 内置</td>
+<td>❌ User/session/agent state，不是这套双轨</td>
+<td>❌ Multi-layer memory，不是这套双轨</td>
+<td>❌ 偏 conversation/project recall</td>
+<td>❌ 偏 personal memory passport</td>
+<td>❌ 偏 app memory 或 graph</td>
 </tr>
 <tr>
-<td><strong>可携带的作用域</strong></td>
-<td>✅ 可按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 正交检索。</td>
-<td>❌ 作用域常常围绕单一 app、thread、tenant 或自定义 schema 展开。</td>
+<td><strong>正交检索作用域</strong><br><sub>按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 检索。</sub></td>
+<td>✅ 内置</td>
+<td>❌ 作用域模型不同</td>
+<td>❌ 作用域模型不同</td>
+<td>❌ Wing / room 式作用域</td>
+<td>❌ Product account / connector 作用域</td>
+<td>❌ Namespace / graph / app 作用域</td>
 </tr>
 <tr>
-<td><strong>可审计的进化</strong></td>
-<td>✅ 重复经验可以沉淀为 reusable skills，同时原始记忆仍是可编辑 Markdown；Knowledge Wiki 和 Reflection 会让进化过程保持可检查。</td>
-<td>❌ 即使支持 evolution，通常也发生在 service state、graph 或 dashboard 内，而不是可编辑源文件上。</td>
+<td><strong>Markdown-native evolution</strong><br><sub>Skills、即将推出的 Knowledge Wiki 和 Reflection 都从可检查源文件中进化。</sub></td>
+<td>✅ 围绕文件构建</td>
+<td>❌ Evolution 不是 Markdown-native</td>
+<td>❌ Evolution 不是 Markdown-native</td>
+<td>❌ Retrieval-first，没有 Markdown-native evolution</td>
+<td>❌ Reflection 是产品状态，不是 Markdown-native</td>
+<td>❌ Evolution 存在于 stores 或 graphs 中</td>
 </tr>
 </table>
 
-<sub>这里比较的是公开 memory-library repos 的默认产品取向，不代表每一种可选后端或部署模式。</sub>
+<sub>✅ = 公开 docs 中的一等 / 默认能力。❌ = 公开 docs 中未作为一等 / 默认能力呈现。Mem0 有时也被写作 MemZero；MemoryLake 对应 MemLake 这个简称。</sub>
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,7 +21,7 @@
 
 <br>
 
-- [EverOS 1.0.0 亮点](#everos-100-亮点)
+- [EverOS 1.0.0](#everos-100)
 - [为什么选择 EverOS](#为什么选择-everos)
 - [EverOS 的差异](#everos-的差异)
 - [快速开始](#快速开始)
@@ -40,7 +40,7 @@
 </details>
 
 
-## EverOS 1.0.0 亮点
+## EverOS 1.0.0
 
 > [!IMPORTANT]
 >
@@ -52,43 +52,6 @@
 > **即将推出：** Knowledge Wiki 会把记忆整理成可编辑、可溯源的
 > Markdown 知识页。Reflection（也称 Dreaming）会在离线时连接信号、
 > 压缩历史，并持续改进 profile 和 skills。
-
-<table>
-<tr>
-<td width="33%" valign="top">
-<strong>Markdown As Source Of Truth</strong><br>
-<br>
-所有记忆持久化为 <code>.md</code> 文件：可读、可改、可 grep、可 Git 版本化，也可直接用 Obsidian 打开。
-</td>
-<td width="33%" valign="top">
-<strong>Local Three-Part Stack</strong><br>
-<br>
-Markdown + SQLite + LanceDB 在本地完成向量、BM25 和标量过滤检索，无需 MongoDB、Elasticsearch 或 Redis。
-</td>
-<td width="33%" valign="top">
-<strong>Dual-Track Memory</strong><br>
-<br>
-Agent 记忆（<code>cases</code> / <code>skills</code>）与用户记忆（<code>episodes</code> / <code>profile</code>）独立提取，互不污染。
-</td>
-</tr>
-<tr>
-<td width="33%" valign="top">
-<strong>Multimodal Ingestion</strong><br>
-<br>
-文本、图像、音频、文档、PDF、HTML 和邮件统一抽取为可检索的记忆形态。
-</td>
-<td width="33%" valign="top">
-<strong>Self-Evolution</strong><br>
-<br>
-从真实使用经验中自动抽取共性 skills，重复模式沉淀为可复用流程，无需重训。
-</td>
-<td width="33%" valign="top">
-<strong>Orthogonal Retrieval</strong><br>
-<br>
-按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 五维独立检索。
-</td>
-</tr>
-</table>
 
 <br>
 <div align="right">
@@ -167,14 +130,20 @@ EverOS 的差异在于：Markdown 是标准记忆层，而不是 export、log �
 <td>❌ 通常按 folder、project 或 conversation 来组织</td>
 </tr>
 <tr>
-<td><strong>Markdown-native evolution</strong><br><sub>Skills、即将推出的 Knowledge Wiki 和 Reflection 都从可检查源文件中进化。</sub></td>
-<td>✅ 围绕文件构建</td>
-<td>❌ 如果支持 evolution，通常存在于 service、graph 或 database state</td>
-<td>❌ 通常偏 recall，而不是 file-native self-evolution</td>
+<td><strong>Knowledge Wiki</strong><br><sub>记忆应该沉淀为可编辑、可溯源的知识页。</sub></td>
+<td>✅ 即将推出：由记忆生成 Markdown wiki 知识页</td>
+<td>❌ 通常是 retrieval、graph、dashboard 或 generated summary state</td>
+<td>✅ 往往像 wiki，但通常是手写内容，或与 runtime memory 分离</td>
+</tr>
+<tr>
+<td><strong>Dreaming / Reflection</strong><br><sub>离线整理应该连接信号，并改善长期行为。</sub></td>
+<td>✅ 即将推出：围绕 profiles、skills 和 wiki 做离线 Reflection</td>
+<td>❌ 通常是在线读写 API，而不是基于文件的自我改进</td>
+<td>❌ 通常偏笔记召回或摘要，不是运行时记忆进化</td>
 </tr>
 </table>
 
-<sub>✅ 表示默认取向中的一等能力。❌ 表示该类型通常没有，或并不是核心设计中心。这是 product-shape comparison，不表示没有任何单个项目具备相邻能力。</sub>
+<sub>✅ 表示当前或已宣布默认取向中的一等能力。❌ 表示该类型通常没有，或并不是核心设计中心。这是 product-shape comparison，不表示没有任何单个项目具备相邻能力。</sub>
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center" id="readme-top">
 
-![EverOS banner](https://github.com/EverMind-AI/EverOS/releases/download/v1.0.0/everos-readme-banner-optimized.jpg)
+![EverOS banner](https://github.com/user-attachments/assets/8e217d39-5d15-4c6c-9b54-3e83add4e0f2)
 
 <p align="center">
   <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
@@ -48,8 +48,9 @@
 > 多模态摄取、用户记忆与 Agent 记忆作用域，以及由
 > [EverAlgo](https://github.com/EverMind-AI/EverAlgo) 支撑的模块化算法。
 >
-> **欢迎 Watch 这个仓库。** 下一阶段我们会继续推进记忆系统方法，
-> 包括 Wiki 式知识层和用于更深层离线进化的 Dreaming。
+> **即将推出：** Knowledge Wiki 会把记忆整理成可编辑、可溯源的
+> Markdown 知识页。Reflection（也称 Dreaming）会在离线时连接信号、
+> 压缩历史，并持续改进 profile 和 skills。
 
 <table>
 <tr>
@@ -651,8 +652,30 @@ Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 
 ## 关注 EverOS
 
 EverOS 1.0.0 是更大规模记忆系统路线图的第一个发布版本。Watch 这个仓库，
-即可持续关注 Wiki 式记忆、Dreaming、更深入的离线进化、benchmark releases，
-以及更多真实 Agent 集成。
+即可持续关注更深入的离线进化、benchmark releases，以及更多真实 Agent 集成。
+
+<table>
+<tr>
+<td width="50%" valign="top">
+<strong>Knowledge Wiki</strong><br>
+<br>
+把分散的 episodes、files、facts 和 Agent traces 整理成有来源的 Markdown
+知识页，覆盖 people、projects、topics、decisions 和 workflows。记忆不再只是
+向量召回结果，而是用户可以阅读、修正、链接、版本化，并用现有 Markdown 工具打开的知识层。
+</td>
+<td width="50%" valign="top">
+<strong>Dreaming / Reflection</strong><br>
+<br>
+在活跃会话之间离线运行，重新审视已存储记忆，连接弱信号，把嘈杂历史压缩成稳定模式，
+并持续改进 profile 和 skills。目标是让 Agent 在你离开时也能变得更好，
+而不是只在你 prompt 它时才进步。
+</td>
+</tr>
+</table>
+
+许多记忆系统停留在聊天历史、黑盒 profile 或向量召回。EverOS 的差异在于：
+记忆保持本地、Markdown-native、可审计、可自进化；原始记忆仍然可读，
+衍生知识沉淀为 wiki，Reflection 则把重复经验转化为更有用的长期行为。
 
 如果 EverOS 对你的 Agent stack 有帮助，Star 这个仓库也会帮助更多 builders
 发现它。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,15 +115,11 @@ EverOS 是面向 agents 和 makers 的本地记忆操作系统。它提供一层
 
 ## EverOS 的差异
 
-下面这张表比较的是常见 memory-library 架构类型，而不是点名具体仓库。
-有些项目会跨多个类型，也确实有项目提供 file-oriented 或 Markdown-like 能力。
-EverOS 的差异在于：Markdown 是标准记忆层，而不是 export、log 或 integration target。
-
 <table>
 <tr>
 <th width="28%">Title</th>
 <th width="36%">EverOS</th>
-<th width="36%">Agent Memory libraries</th>
+<th width="36%">Other Agent Memory Libraries</th>
 </tr>
 <tr>
 <td><strong>Markdown source of truth</strong></td>
@@ -152,17 +148,15 @@ EverOS 的差异在于：Markdown 是标准记忆层，而不是 export、log �
 </tr>
 <tr>
 <td><strong>Knowledge Wiki</strong></td>
-<td>✅ 即将推出：由记忆生成 Markdown wiki 知识页</td>
-<td>❌ 通常是 retrieval、graph、dashboard 或 generated summary state</td>
+<td>✅ 即将推出：由记忆形成可编辑、可溯源的 Markdown 知识页</td>
+<td>❌ 通常是 retrieval、graph、dashboard 或 generated summaries，而不是可编辑、可溯源的知识页</td>
 </tr>
 <tr>
 <td><strong>Dreaming / Reflection</strong></td>
-<td>✅ 即将推出：围绕 profiles、skills 和 wiki 做离线 Reflection</td>
-<td>❌ 通常是在线读写 API，而不是基于文件的自我改进</td>
+<td>✅ 即将推出：离线连接信号、压缩历史，并在 session 之间改进 profiles 和 skills</td>
+<td>❌ 通常是在线读写 API、retrieval records 或 summaries，而不是离线记忆整理</td>
 </tr>
 </table>
-
-<sub>✅ 表示当前或已宣布默认取向中的一等能力。❌ 表示该类型通常没有，或并不是核心设计中心。这是 product-shape comparison，不表示没有任何单个项目具备相邻能力。</sub>
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,76 +125,56 @@ EverOS 会把对话、Agent 轨迹和文件保存为可读 Markdown，并同步�
 
 ## EverOS 的差异
 
-下面这张表对比的是公开 memory-library repos 和 docs 中的一等、默认、
-开发者可见能力。它比较的是产品默认取向，不覆盖每一种可选后端或企业部署模式。
+下面这张表比较的是常见 memory-library 架构类型，而不是点名具体仓库。
+有些项目会跨多个类型，也确实有项目提供 file-oriented 或 Markdown-like 能力。
+EverOS 的差异在于：Markdown 是标准记忆层，而不是 export、log 或 integration target。
 
 <table>
 <tr>
-<th width="22%">能力</th>
-<th width="13%">EverOS</th>
-<th width="13%">Mem0</th>
-<th width="13%">MemOS</th>
-<th width="13%">MemPalace</th>
-<th width="13%">MemoryLake</th>
-<th width="13%">LangMem / Cognee / Graphiti</th>
+<th width="24%">开发者关心什么</th>
+<th width="28%">EverOS default</th>
+<th width="24%">常见 memory libraries</th>
+<th width="24%">File / Markdown-adjacent tools</th>
 </tr>
 <tr>
 <td><strong>Markdown source of truth</strong><br><sub>记忆以文件形式可读、可编辑、可 diff、可 Git 版本化。</sub></td>
 <td>✅ 标准 <code>.md</code> 记忆</td>
-<td>❌ API / backend memory</td>
-<td>❌ Memory cubes / service state</td>
-<td>❌ Verbatim store + backend index</td>
-<td>❌ Hosted memory passport</td>
-<td>❌ Store / graph / platform state</td>
+<td>❌ 通常是 API、vector、graph、dashboard 或 database state</td>
+<td>✅ 往往可读，但不一定是完整 runtime source of truth</td>
 </tr>
 <tr>
 <td><strong>直接文件编辑</strong><br><sub>用普通开发者工具编辑记忆，然后同步索引。</sub></td>
 <td>✅ 编辑 <code>.md</code>；cascade watcher 同步</td>
-<td>❌ SDK / API 路径</td>
-<td>❌ API / dashboard 路径</td>
-<td>❌ CLI / backend 路径</td>
-<td>❌ App / API 路径</td>
-<td>❌ Store / graph API 路径</td>
+<td>❌ 通常需要 SDK、API、dashboard 或 backend update path</td>
+<td>✅ 有些可以做到，但常常缺少 entry-level index sync</td>
 </tr>
 <tr>
 <td><strong>本地三件套</strong><br><sub>Markdown + SQLite + LanceDB；不需要 MongoDB、Elasticsearch 或 Redis。</sub></td>
 <td>✅ 内置</td>
-<td>❌ Vector / service stack</td>
-<td>❌ Cloud 或 self-hosted service stack</td>
-<td>❌ Chroma / pluggable backend stack</td>
-<td>❌ Hosted product stack</td>
-<td>❌ Graph / database / platform stack</td>
+<td>❌ 常依赖 managed service、vector DB、graph DB 或 server stack</td>
+<td>❌ 往往本地，但通常绑定另一套 index/backend model</td>
 </tr>
 <tr>
 <td><strong>用户 + Agent 双轨</strong><br><sub>用户 <code>episodes/profile</code> 与 Agent <code>cases/skills</code> 是分离的一等记忆表面。</sub></td>
 <td>✅ 内置</td>
-<td>❌ User/session/agent state，不是这套双轨</td>
-<td>❌ Multi-layer memory，不是这套双轨</td>
-<td>❌ 偏 conversation/project recall</td>
-<td>❌ 偏 personal memory passport</td>
-<td>❌ 偏 app memory 或 graph</td>
+<td>❌ 通常围绕 chat history、profiles、entities、facts 或 retrieval records</td>
+<td>❌ 通常围绕 logs、notes、projects 或 conversations</td>
 </tr>
 <tr>
 <td><strong>正交检索作用域</strong><br><sub>按 <code>user_id</code>、<code>agent_id</code>、<code>app_id</code>、<code>project_id</code> 和 <code>session_id</code> 检索。</sub></td>
 <td>✅ 内置</td>
-<td>❌ 作用域模型不同</td>
-<td>❌ 作用域模型不同</td>
-<td>❌ Wing / room 式作用域</td>
-<td>❌ Product account / connector 作用域</td>
-<td>❌ Namespace / graph / app 作用域</td>
+<td>❌ 通常按 app、namespace、tenant、thread 或 graph 来组织</td>
+<td>❌ 通常按 folder、project 或 conversation 来组织</td>
 </tr>
 <tr>
 <td><strong>Markdown-native evolution</strong><br><sub>Skills、即将推出的 Knowledge Wiki 和 Reflection 都从可检查源文件中进化。</sub></td>
 <td>✅ 围绕文件构建</td>
-<td>❌ Evolution 不是 Markdown-native</td>
-<td>❌ Evolution 不是 Markdown-native</td>
-<td>❌ Retrieval-first，没有 Markdown-native evolution</td>
-<td>❌ Reflection 是产品状态，不是 Markdown-native</td>
-<td>❌ Evolution 存在于 stores 或 graphs 中</td>
+<td>❌ 如果支持 evolution，通常存在于 service、graph 或 database state</td>
+<td>❌ 通常偏 recall，而不是 file-native self-evolution</td>
 </tr>
 </table>
 
-<sub>✅ = 公开 docs 中的一等 / 默认能力。❌ = 公开 docs 中未作为一等 / 默认能力呈现。Mem0 有时也被写作 MemZero；MemoryLake 对应 MemLake 这个简称。</sub>
+<sub>✅ 表示默认取向中的一等能力。❌ 表示该类型通常没有，或并不是核心设计中心。这是 product-shape comparison，不表示没有任何单个项目具备相邻能力。</sub>
 
 <br>
 <div align="right">


### PR DESCRIPTION
## Summary
- Keeps the top README release callout compact while still naming Knowledge Wiki and Dreaming / Reflection as upcoming features.
- Reworks the second section into `EverOS: One Memory For All`, places the current-state EverOS paragraph above the six highlight cards, and keeps the old three boundary bullets removed.
- Simplifies the positioning table to three columns: `Title`, `EverOS`, and `Other Agent Memory Libraries`.
- Removes the extra paragraph above the comparison table and the small disclaimer below it.
- Clarifies Reflection / Dreaming as idle-or-offline work, not offline-only work.
- Mirrors the same structure and messaging in `README.zh-CN.md`.

## Research Notes
- Checked public positioning/docs across memory-library categories, including API/platform memory, graph/knowledge memory, local recall tools, and file/Markdown-adjacent tools.
- The comparison is intentionally scoped to broad architecture categories and product posture, not absolute claims about individual repos.

## Test Plan
- `git diff --check`
- `make docs-check`
- `make test`
