### PR TITLE
docs: fix Discord community links

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -97,7 +97,7 @@ Thanks to our community for valuable feedback, bug reports, and feature
 suggestions:
 
 - **GitHub Issues & Discussions** — bug reports and feature requests
-- **Discord** — [Join our Discord server](https://discord.gg/pfwwskxp)
+- **Discord** — [Join our Discord server](https://discord.gg/gYep5nQRZJ)
 - **X / Twitter** — [@EverMindAI](https://x.com/EverMindAI)
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ What we actively welcome from the community:
 | 🐛 Bug reports | [Open a bug issue](https://github.com/EverMind-AI/EverOS/issues/new?template=bug_report.yml) |
 | 💡 Feature ideas / use cases | [Open a feature issue](https://github.com/EverMind-AI/EverOS/issues/new?template=feature_request.yml) |
 | 🔧 Focused fixes | A pull request linked to a bug, design note, or clear reproduction |
-| ❓ Questions & discussion | [GitHub Discussions](https://github.com/EverMind-AI/EverOS/discussions) / [Discord](https://discord.gg/pfwwskxp) |
+| ❓ Questions & discussion | [GitHub Discussions](https://github.com/EverMind-AI/EverOS/discussions) / [Discord](https://discord.gg/gYep5nQRZJ) |
 
 Large architectural changes should start as an issue or discussion before code.
 Small documentation, test, CI, and bug-fix PRs can be opened directly.
@@ -65,7 +65,7 @@ are expected to uphold it. Report unacceptable behavior to evermind@shanda.com.
 ## Questions
 
 - [GitHub Discussions](https://github.com/EverMind-AI/EverOS/discussions) — general Q&A
-- [Discord](https://discord.gg/pfwwskxp) — community chat
+- [Discord](https://discord.gg/gYep5nQRZJ) — community chat
 - Email: evermind@shanda.com
 
 ---


### PR DESCRIPTION
## What changed

- Updated outdated Discord invite links in `CONTRIBUTING.md`.
- Updated the outdated Discord invite link in `ACKNOWLEDGMENTS.md`.
- Kept the README banner Discord link as the canonical invite: `https://discord.gg/gYep5nQRZJ`.

## Why

The repository had older Discord invite URLs outside the README. This keeps community links consistent with the canonical invite shown at the top of the GitHub repo.

## Validation

- `python3 scripts/check_docs.py`
- `rg -n "pfwwskxp" -S --glob '!node_modules' --glob '!dist' --glob '!build'`
- `git diff --check -- ACKNOWLEDGMENTS.md CONTRIBUTING.md`
