### PR TITLE
docs(readme): remove demo hosting sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ scope and TUI source layout.
 
 The sphere moves through ingest, extraction, indexing, recall, source reveal,
 and a confetti burst after the first memory lands. Press `r` to replay and `q`
-to quit. The optimized animated preview is externally hosted so the repository
-stays light:
+to quit.
 
 <p align="center">
   <img src="https://gist.githubusercontent.com/cyfyifanchen/afa2cf40bf138a3ec96d917e8f2791a2/raw/d4ce82a6ddd7b3ebaf221e4825af993aeca5a7ce/everos-demo-tui-animation.svg" alt="Animated EverOS demo preview showing the memory sphere moving through recall and confetti states" width="720">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,7 +134,7 @@ conversation -> memory sphere -> recall -> source proof -> confetti。Demo
 
 Sphere 会经历 ingest、extraction、indexing、recall、source reveal，
 并在第一条记忆落地后进入 confetti successful moment。按 `r` 可以 replay，
-按 `q` 可以退出。下面的优化动图托管在外部，避免仓库变重：
+按 `q` 可以退出。
 
 <p align="center">
   <img src="https://gist.githubusercontent.com/cyfyifanchen/afa2cf40bf138a3ec96d917e8f2791a2/raw/d4ce82a6ddd7b3ebaf221e4825af993aeca5a7ce/everos-demo-tui-animation.svg" alt="Animated EverOS demo preview showing the memory sphere moving through recall and confetti states" width="720">


### PR DESCRIPTION
## Summary
- Remove the hosted-preview explanatory sentence from the English README demo section
- Remove the matching Chinese sentence from the Chinese README demo section
- Keep the demo GIF and the demo usage instructions unchanged

## Validation
- git diff --check
- make docs-check
