### PR TITLE
docs: index all docs and add a Tutorials section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,16 @@ Documentation for [EverOS](../README.md) — md-first memory extraction
 framework. Organised by [Diátaxis](https://diataxis.fr/) — what kind of
 question you have determines which section to read.
 
+## Tutorials
+
+Learning-oriented entry points — start here to get a feel for the system
+before wiring it into a real workflow.
+
+| Doc | Purpose |
+|---|---|
+| [everos-demo.md](everos-demo.md) | `everos demo` — local educational TUI to feel the memory lifecycle before configuring keys |
+| [use-cases.md](use-cases.md) | Worked examples and integrations showing what persistent memory enables, to study and adapt |
+
 ## Reference
 
 Technical reference: contracts, commands, schemas — read these when you
@@ -15,6 +25,8 @@ already know what you want to do and need to know exactly how.
 | [knowledge.md](knowledge.md) | Knowledge base module — upload, search, taxonomy, storage layout |
 | [reflection.md](reflection.md) | Reflection — offline memory consolidation: enable, schedule, storage, triggering |
 | [cli.md](cli.md) | `everos` CLI subcommands + env var conventions |
+| [configuration.md](configuration.md) | Two-file TOML configuration + environment-variable overrides for container deployments |
+| [multimodal.md](multimodal.md) | Multimodal ingest — supported modalities, `uri` vs `base64` payloads, required extras/config |
 | [storage_layout.md](storage_layout.md) | Memory-root tree + frontmatter chassis + EntryId encoding |
 | [prompt_slots.md](prompt_slots.md) | YamlConfigLoader + three-layer prompt override |
 
@@ -38,6 +50,8 @@ specific thing (drain a queue, recover from a stuck row, etc.).
 | Doc | Purpose |
 |---|---|
 | [cascade_runbook.md](cascade_runbook.md) | Cascade subsystem ops — drain queue, recover stuck rows |
+| [locomo_benchmark.md](locomo_benchmark.md) | Reproduce EverOS's LoCoMo retrieval scores locally (`hybrid` / `agentic`) |
+| [migration-to-1.0.0.md](migration-to-1.0.0.md) | Migrate off pre-1.0.0 APIs / infrastructure to the current 1.0.0 contract |
 
 ## Engineering / Internal
 
@@ -56,6 +70,7 @@ Top-level project files live next to the repo root:
 - [QUICKSTART.md](../QUICKSTART.md) — 5-minute walkthrough (install → service → search)
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — how to contribute (issue-only model)
 - [CHANGELOG.md](../CHANGELOG.md) — release notes
+- [release-notes-1.1.0.md](release-notes-1.1.0.md) — EverOS 1.1.0 highlights (Knowledge, Reflection, OME)
 - [SECURITY.md](../SECURITY.md) — security policy & private vulnerability reporting
 - [CITATION.md](../CITATION.md) — academic citation info
 - [ACKNOWLEDGMENTS.md](../ACKNOWLEDGMENTS.md) — third-party acknowledgments


### PR DESCRIPTION
## What

`docs/index.md` only linked **12 of the 19** docs under `docs/`. Anyone entering the documentation through the index page silently missed 7 files — including core usage docs like configuration and multimodal.

This PR makes the index complete and adds the missing Diátaxis quadrant.

## Changes

| Section | Added |
|---|---|
| **Tutorials** (new — Diátaxis 4th quadrant, was absent) | `everos-demo.md`, `use-cases.md` |
| **Reference** | `configuration.md`, `multimodal.md` |
| **How-to** | `locomo_benchmark.md`, `migration-to-1.0.0.md` |
| **See also** | `release-notes-1.1.0.md` |

After this change, every `docs/*.md` (excluding the generated `openapi.json` artifact and `index.md` itself) is linked from the index.

## Notes / judgment calls for reviewers

- `use-cases.md` is a product showcase rather than a strict guided tutorial; placed under **Tutorials** as the least-bad fit (learning/exploration oriented). Move to See also if you prefer.
- `multimodal.md` straddles Reference/How-to; filed under **Reference** since it documents modalities + payload formats. 
- Categorization is easy to shuffle — happy to adjust.

## Scope

Docs only. No code, no API, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)