### PR TITLE
[codex] introduce Raven README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,8 @@
-<div align="center" id="readme-top">
+# Raven
 
-![EverOS banner](https://github.com/user-attachments/assets/8e217d39-5d15-4c6c-9b54-3e83add4e0f2)
+Raven is **The Self-Improving Agent Harness**, built on [EverOS](https://github.com/EverMind-AI/EverOS).
 
-<p align="center">
-  <a href="https://x.com/evermind"><img src="https://img.shields.io/badge/EverMind-000000?labelColor=gray&style=for-the-badge&logo=x&logoColor=white" alt="X"></a>
-  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/🤗_HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
-  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
-</p>
-
-[Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [Blog](https://evermind.ai/blogs) · [中文](README.zh-CN.md)
-
-</div>
-
-
-<br>
+Raven helps agents improve across runs by continuously refining the systems around them: tools, skills, memory, code execution, policies, and working environment. EverOS provides durable user memory, agent memory, and world knowledge across sessions, so successful workflows can evolve into reusable Agent Templates and digital workers.
 
 <details>
   <summary><kbd>Table of Contents</kbd></summary>


### PR DESCRIPTION
## What changed

- Replaced the README top banner/header block with a concise Raven introduction.
- Added the confirmed positioning copy for Raven as **The Self-Improving Agent Harness** built on EverOS.

## Why

This gives the README first screen a clearer Raven-focused positioning statement while keeping the existing documentation sections unchanged.

## Impact

Documentation-only change. No runtime behavior is affected.

## Validation

- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- Verified the Raven heading and copy are present at the top of `README.md` with `rg`.