### PR TITLE
fix(search): scope deprecated_by filter to user tables only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-07
+
+### Fixed
+
+- **Agent-track search broken by `deprecated_by IS NULL` filter** —
+  `compile_filters()` unconditionally appended a `deprecated_by IS NULL`
+  clause to every LanceDB query, but only `episode` and `atomic_fact`
+  tables have this column. Agent-track search (`agent_case`,
+  `agent_skill`) failed on any method. The clause is now conditional on
+  `owner_type == "user"`.
+
 ## [1.1.1] - 2026-07-06
 
 ### Added
@@ -215,7 +226,8 @@ for AI agents.
 - **Decoupled algorithms** — memory extraction algorithms live in the standalone
   `everalgo-*` libraries published on PyPI.
 
-[Unreleased]: https://github.com/EverMind-AI/everos/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/EverMind-AI/everos/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/EverMind-AI/everos/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/EverMind-AI/everos/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/EverMind-AI/everos/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/EverMind-AI/everos/releases/tag/v1.0.1

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "everos",
     "description": "md-first memory extraction framework",
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "paths": {
     "/health": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "everos"
-version = "1.1.1"
+version = "1.1.2"
 description = "EverOS — local-first markdown memory framework for AI agents and user chats; lightweight, dev-friendly, small-team"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/src/everos/memory/search/filters.py
+++ b/src/everos/memory/search/filters.py
@@ -107,8 +107,11 @@ def compile_filters(
         f"owner_type = '{owner_type}'",
         f"app_id = '{_escape_str(app_id)}'",
         f"project_id = '{_escape_str(project_id)}'",
-        "deprecated_by IS NULL",
     ]
+    # Only episode / atomic_fact tables carry the ``deprecated_by`` column
+    # (Reflection V1 marks superseded entries). Agent tables don't have it.
+    if owner_type == "user":
+        base.append("deprecated_by IS NULL")
     if node is None:
         return " AND ".join(base)
     compiled = _compile_node(node.model_dump(exclude_none=True))

--- a/tests/unit/test_memory/test_get/test_filters_adapter.py
+++ b/tests/unit/test_memory/test_get/test_filters_adapter.py
@@ -33,6 +33,12 @@ def test_no_filters_emits_base_clause() -> None:
     )
 
 
+def test_no_filters_agent_omits_deprecated_by() -> None:
+    """Agent tables lack ``deprecated_by`` — clause must be absent."""
+    where = compile_filters_for_get(None, owner_id="bot", owner_type="agent")
+    assert "deprecated_by" not in where
+
+
 def test_owner_id_quote_is_escaped() -> None:
     """SQL-standard double-quote escape on ``owner_id``."""
     where = compile_filters_for_get(None, owner_id="o'reilly", owner_type="user")

--- a/tests/unit/test_memory/test_search/test_filters.py
+++ b/tests/unit/test_memory/test_search/test_filters.py
@@ -22,6 +22,15 @@ def test_no_filters_emits_base_clause() -> None:
     )
 
 
+def test_no_filters_agent_omits_deprecated_by() -> None:
+    where = compile_filters(None, owner_id="bot_42", owner_type="agent")
+    assert "deprecated_by" not in where
+    assert where == (
+        "owner_id = 'bot_42' AND owner_type = 'agent' "
+        "AND app_id = 'default' AND project_id = 'default'"
+    )
+
+
 def test_owner_type_agent_pinned() -> None:
     where = compile_filters(None, owner_id="alice", owner_type="agent")
     assert "owner_type = 'agent'" in where
@@ -249,6 +258,11 @@ def test_empty_and_array_skips_combinator() -> None:
 # ── Deprecated exclusion ──────────────────────────────────────────────
 
 
-def test_compile_filters_excludes_deprecated_by_default() -> None:
+def test_compile_filters_excludes_deprecated_by_for_user() -> None:
     result = compile_filters(None, owner_id="u_a", owner_type="user")
     assert "deprecated_by IS NULL" in result
+
+
+def test_compile_filters_omits_deprecated_by_for_agent() -> None:
+    result = compile_filters(None, owner_id="agent_1", owner_type="agent")
+    assert "deprecated_by" not in result

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "everos"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`compile_filters()` unconditionally appended `deprecated_by IS NULL` to every LanceDB query, but the `deprecated_by` column only exists on user-scoped tables (episode, atomic_fact — Reflection V1). Agent tables (agent_case, agent_skill) lack this column, causing a SQL error on agent search/get queries.

**Fix**: gate the clause behind `owner_type == "user"` so agent queries no longer reference a non-existent column.

Also bumps version to **1.1.2**.

## Area

- [x] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

```text
make lint          # all gates pass (ruff, import-linter, datetime, openapi drift, etc.)
make test          # 1477 passed; 20 failures are pre-existing jieba SyntaxError on Python 3.14 (upstream)
pytest tests/unit/test_memory/test_search/test_filters.py tests/unit/test_memory/test_get/test_filters_adapter.py -v
                   # 52 passed — includes 2 new tests:
                   #   test_compile_filters_excludes_deprecated_by_for_user
                   #   test_compile_filters_omits_deprecated_by_for_agent
```

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [x] I added or updated tests when the change affects behavior.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

- The `exclude_deprecated` parameter was already removed from the public API in v1.1.1 (15efd11), but the unconditional `deprecated_by IS NULL` clause remained in `compile_filters()`. This PR completes that cleanup.
- `docs/openapi.json` regenerated via `make openapi` to match the 1.1.2 version bump.

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.