### PR TITLE
Add token-count badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/🤗_HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge" alt="HuggingFace"></a>
   <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <img src="https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/EverMind-AI/EverOS" alt="tokens">
 </p>
 
 [Website](https://evermind.ai) · [Documentation](https://docs.evermind.ai) · [Blog](https://evermind.ai/blogs) · [中文](README.zh-CN.md)


### PR DESCRIPTION
Hi! This PR adds one line to the README: a badge showing an estimate of how many LLM tokens this repo weighs. Since this project is the kind of thing people load into an LLM's context window, the number seemed genuinely useful to surface.

Preview: ![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/EverMind-AI/EverOS)

Full disclosure: I built the free, open-source service behind the badge (https://github.com/rsamf/gittokens), and I'm proposing it to a small, hand-picked set of repos where it seems like a good fit. If it isn't a fit here, please just close this, and I won't resubmit.