### PR TITLE
fix(cascade): repair knowledge topic SQLite parity

### DIFF
--- a/src/everos/memory/cascade/handlers/knowledge_topic.py
+++ b/src/everos/memory/cascade/handlers/knowledge_topic.py
@@ -29,6 +29,7 @@ Embedding source: ``summary`` (mirrors the search recaller's anchor).
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from typing import Any, ClassVar
 
@@ -91,8 +92,25 @@ class KnowledgeTopicHandler(Handler):
             }
         )
 
+        topic_payload = self._build_sqlite_payload(fields, md_path)
+
         prior = await knowledge_topic_repo.get_by_id(fields["node_id"])
         if prior is not None and prior.content_sha256 == digest:
+            rows = await knowledge_topic_sqlite_repo.get_topics_by_ids(
+                [fields["node_id"]]
+            )
+            if not rows or not self._sqlite_row_matches_payload(
+                rows[0],
+                topic_payload,
+            ):
+                await knowledge_topic_sqlite_repo.upsert_from_handler(topic_payload)
+                return HandlerOutcome(
+                    md_path=md_path,
+                    kind=self.kind,
+                    upserted=1,
+                    deleted=0,
+                    skipped=0,
+                )
             return HandlerOutcome(
                 md_path=md_path,
                 kind=self.kind,
@@ -104,7 +122,6 @@ class KnowledgeTopicHandler(Handler):
         row = await self._build_lance_row(fields, digest, md_path)
         await knowledge_topic_repo.upsert([row])
 
-        topic_payload = self._build_sqlite_payload(fields, md_path)
         await knowledge_topic_sqlite_repo.upsert_from_handler(topic_payload)
 
         return HandlerOutcome(
@@ -114,6 +131,18 @@ class KnowledgeTopicHandler(Handler):
             deleted=0,
             skipped=0,
         )
+
+    def _sqlite_row_matches_payload(
+        self,
+        row: Any,
+        payload: TopicUpsertPayload,
+    ) -> bool:
+        """Return whether SQLite already mirrors the parsed topic payload."""
+        for key, value in dataclasses.asdict(payload).items():
+            current = row.get(key) if isinstance(row, dict) else getattr(row, key, None)
+            if current != value:
+                return False
+        return True
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/tests/unit/test_memory/test_cascade/test_handler_knowledge_topic.py
+++ b/tests/unit/test_memory/test_cascade/test_handler_knowledge_topic.py
@@ -86,6 +86,9 @@ class _FakeSqliteRepo:
         self.upserts.append(data)
         self.rows[payload.node_id] = data
 
+    async def get_topics_by_ids(self, node_ids: list[str]) -> list[dict]:
+        return [self.rows[nid] for nid in node_ids if nid in self.rows]
+
     async def delete_by_md_path(self, md_path: str) -> int:
         self.deletes.append(md_path)
         before = len(self.rows)
@@ -230,7 +233,7 @@ async def test_handle_added_or_modified_upserts_to_both_stores(
     assert sq["md_path"] == md_path
 
 
-async def test_same_digest_skips(
+async def test_same_digest_skips_when_sqlite_matches(
     memory_root: MemoryRoot,
     fake_lance: _FakeLanceRepo,
     fake_sqlite: _FakeSqliteRepo,
@@ -248,6 +251,54 @@ async def test_same_digest_skips(
     # Only one upsert batch total.
     assert len(fake_lance.upserts) == 1
     assert len(fake_sqlite.upserts) == 1
+
+
+async def test_same_digest_repairs_missing_sqlite_row(
+    memory_root: MemoryRoot,
+    fake_lance: _FakeLanceRepo,
+    fake_sqlite: _FakeSqliteRepo,
+) -> None:
+    """If LanceDB is current but SQLite lost the row, rehydrate SQLite."""
+    md_path = _write_topic_md(memory_root)
+    handler = _handler(memory_root)
+
+    first = await handler.handle_added_or_modified(md_path)
+    assert first.upserted == 1
+
+    fake_sqlite.rows.clear()
+    fake_sqlite.upserts.clear()
+
+    second = await handler.handle_added_or_modified(md_path)
+
+    assert second.upserted == 1
+    assert second.skipped == 0
+    assert len(fake_lance.upserts) == 1
+    assert len(fake_sqlite.upserts) == 1
+    assert fake_sqlite.upserts[0]["node_id"] == "node_001"
+
+
+async def test_same_digest_repairs_stale_sqlite_row(
+    memory_root: MemoryRoot,
+    fake_lance: _FakeLanceRepo,
+    fake_sqlite: _FakeSqliteRepo,
+) -> None:
+    """If LanceDB is current but SQLite differs, refresh SQLite."""
+    md_path = _write_topic_md(memory_root)
+    handler = _handler(memory_root)
+
+    first = await handler.handle_added_or_modified(md_path)
+    assert first.upserted == 1
+
+    fake_sqlite.rows["node_001"]["summary"] = "stale summary"
+    fake_sqlite.upserts.clear()
+
+    second = await handler.handle_added_or_modified(md_path)
+
+    assert second.upserted == 1
+    assert second.skipped == 0
+    assert len(fake_lance.upserts) == 1
+    assert len(fake_sqlite.upserts) == 1
+    assert fake_sqlite.upserts[0]["summary"] == "Overview of budget planning practices."
 
 
 async def test_wrong_type_skips(


### PR DESCRIPTION
## Summary

Repair the SQLite side of a knowledge-topic cascade write when LanceDB already contains the current content hash.

The handler writes each knowledge topic to both LanceDB and SQLite. If the LanceDB upsert succeeds but the SQLite upsert fails, the retry currently sees the matching LanceDB digest and skips the topic forever. That leaves SQLite missing or stale even though the cascade row is retried.

This change builds the SQLite payload before the digest fast path, verifies that the corresponding SQLite row exists and matches, and repairs only the SQLite side when necessary. The normal unchanged-topic path remains a no-op.

## Area

- [x] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

```text
uv run pytest tests/unit/test_memory/test_cascade/test_handler_knowledge_topic.py -q
8 passed

make ci
1501 unit tests passed; 78 integration tests passed (6 deselected);
lint, architecture contracts, OpenAPI drift, package build, and wheel smoke test passed
```

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] No documentation change is required because the public API and configuration are unchanged.
- [x] I added or updated tests when the change affects behavior.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

The regression test covers both a missing SQLite row and a stale SQLite row while LanceDB already has the matching digest.

By submitting this pull request, I agree that my contribution is licensed under the Apache License 2.0.
