### PR TITLE
fix(lancedb): keep FTS migration nonblocking

### DIFF
--- a/src/everos/infra/persistence/lancedb/__init__.py
+++ b/src/everos/infra/persistence/lancedb/__init__.py
@@ -27,6 +27,8 @@ first access; row population is the cascade daemon's job (see
 import contextlib
 import datetime as dt
 
+import anyio
+
 from everos.core.observability.logging import get_logger
 from everos.core.persistence import MemoryRoot
 
@@ -98,9 +100,11 @@ async def migrate_fts_indexes() -> None:
     O(N) but only on the first startup after upgrade.
     """
     logger = get_logger(__name__)
-    marker = MemoryRoot.default().lancedb_dir / ".fts_index_version"
+    marker = anyio.Path(MemoryRoot.default().lancedb_dir / ".fts_index_version")
     try:
-        current = int(marker.read_text().strip()) if marker.exists() else 0
+        current = (
+            int((await marker.read_text()).strip()) if await marker.exists() else 0
+        )
     except (ValueError, OSError):
         current = 0
     if current >= _FTS_INDEX_SCHEMA_VERSION:
@@ -120,7 +124,7 @@ async def migrate_fts_indexes() -> None:
         # so compaction no longer decodes a position List.
         with contextlib.suppress(Exception):
             await table.optimize(cleanup_older_than=dt.timedelta(seconds=0))
-    marker.write_text(str(_FTS_INDEX_SCHEMA_VERSION))
+    await marker.write_text(str(_FTS_INDEX_SCHEMA_VERSION))
     logger.info("fts_index_migration_done", version=_FTS_INDEX_SCHEMA_VERSION)
 
 

--- a/tests/unit/test_core/test_persistence/test_lancedb/test_fts_behavior.py
+++ b/tests/unit/test_core/test_persistence/test_lancedb/test_fts_behavior.py
@@ -8,6 +8,7 @@ the following configuration::
     stem=True
     remove_stop_words=True
     ascii_folding=True
+    with_position=False
     language="English" (tantivy default)
 
 The app-layer ``JiebaTokenizer`` already handles segmentation +
@@ -22,6 +23,7 @@ as the docstring claims:
   app-layer JiebaTokenizer is the single source of truth for
   stop-word filtering (English + Chinese)
 - ascii_folding=True → diacritics on Latin chars normalised (café → cafe)
+- with_position=False → omit unused phrase-query positions so optimize can compact
 - CJK pass-through → no stemming applied to CJK
 
 Tests build a fresh in-memory-ish LanceDB store under ``tmp_path``,
@@ -33,11 +35,12 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, cast
 
 import lancedb
 import pytest
 from lancedb import AsyncTable
+from lancedb.index import FTS
 
 from everos.core.persistence.lancedb import BaseLanceTable
 
@@ -50,6 +53,25 @@ class _FtsSpec(BaseLanceTable):
 
     id: str
     body: str
+
+
+class _FtsConfigSpy:
+    """Capture index configuration passed through the public schema seam."""
+
+    def __init__(self) -> None:
+        self.created: list[tuple[str, FTS, bool]] = []
+
+    async def list_indices(self) -> list[object]:
+        return []
+
+    async def create_index(
+        self,
+        column: str,
+        *,
+        config: FTS,
+        replace: bool = False,
+    ) -> None:
+        self.created.append((column, config, replace))
 
 
 @pytest.fixture
@@ -73,6 +95,19 @@ async def _query_ids(table: AsyncTable, text: str) -> set[str]:
     """Run a BM25 keyword query over the ``body`` column, return matched ids."""
     rows = await table.query().nearest_to_text(text, columns="body").limit(10).to_list()
     return {r["id"] for r in rows}
+
+
+async def test_fts_index_disables_positions() -> None:
+    """FTS creation omits positions because EverOS does not run phrase queries."""
+    table = _FtsConfigSpy()
+
+    await _FtsSpec.ensure_fts_indexes(cast(AsyncTable, table))
+
+    assert len(table.created) == 1
+    column, config, replace = table.created[0]
+    assert column == "body"
+    assert config.with_position is False
+    assert replace is False
 
 
 # ── lower_case=True ────────────────────────────────────────────────────

--- a/tests/unit/test_core/test_persistence/test_lancedb/test_repository.py
+++ b/tests/unit/test_core/test_persistence/test_lancedb/test_repository.py
@@ -19,6 +19,7 @@ import asyncio
 from pathlib import Path
 from typing import ClassVar
 
+import anyio
 import pytest
 
 from everos.config import LanceDBSettings
@@ -687,12 +688,12 @@ async def test_migrate_fts_indexes_runs_once_and_rebuilds(
         await _SearchNote.ensure_fts_indexes(table)
         assert any("tokens" in (i.columns or []) for i in await table.list_indices())
 
-        marker = MemoryRoot.default().lancedb_dir / ".fts_index_version"
-        assert not marker.exists()
+        marker = anyio.Path(MemoryRoot.default().lancedb_dir / ".fts_index_version")
+        assert not await marker.exists()
 
         # First run: migrates + writes the marker, index still present.
         await migrate_fts_indexes()
-        assert marker.read_text().strip() == "2"
+        assert (await marker.read_text()).strip() == "2"
         assert any("tokens" in (i.columns or []) for i in await table.list_indices())
 
         # Marker present → second run is a no-op. Drop the index, re-run,


### PR DESCRIPTION
## Summary

Keep the one-time FTS schema migration from performing synchronous marker-file I/O inside its async startup path.

`migrate_fts_indexes()` previously called `pathlib.Path.exists()`, `read_text()`, and `write_text()` directly. On a slow or busy filesystem these calls block the event loop during service startup. This change wraps the marker in `anyio.Path` and awaits the file operations while preserving the existing migration/version semantics.

## Area

- [x] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

```text
uv run pytest tests/unit/test_core/test_persistence/test_lancedb/test_fts_behavior.py tests/unit/test_core/test_persistence/test_lancedb/test_repository.py -q
44 passed

make ci
1500 unit tests passed; 78 integration tests passed (6 deselected);
lint, architecture contracts, OpenAPI drift, package build, and wheel smoke test passed
```

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] No documentation change is required because the migration contract is unchanged.
- [x] I added or updated tests when the change affects behavior.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

The tests verify async marker reads and writes for both the migration and already-migrated paths.

By submitting this pull request, I agree that my contribution is licensed under the Apache License 2.0.
