### PR TITLE
fix(markdown): encode agent skill path segments

### DIFF
--- a/src/everos/infra/persistence/markdown/readers/agent_skill_reader.py
+++ b/src/everos/infra/persistence/markdown/readers/agent_skill_reader.py
@@ -25,6 +25,9 @@ from typing import TypeVar
 import anyio
 
 from everos.core.persistence import MarkdownReader, MemoryRoot
+from everos.infra.persistence.markdown.skill_path import (
+    encode_skill_name_segment,
+)
 
 from ..mds import AgentSkillFrontmatter
 
@@ -121,7 +124,10 @@ class AgentSkillReader:
             self._root.agents_dir(app_id, project_id)
             / agent_id
             / AgentSkillFrontmatter.SKILLS_CONTAINER_NAME
-            / f"{AgentSkillFrontmatter.SKILL_DIR_PREFIX}{skill_name}"
+            / (
+                f"{AgentSkillFrontmatter.SKILL_DIR_PREFIX}"
+                f"{encode_skill_name_segment(skill_name)}"
+            )
         )
 
     def _main_path(

--- a/src/everos/infra/persistence/markdown/skill_path.py
+++ b/src/everos/infra/persistence/markdown/skill_path.py
@@ -1,0 +1,17 @@
+"""Map semantic agent-skill names to collision-safe path components.
+
+Skill names remain authoritative human-readable values in frontmatter and
+indexes. Only the filesystem component is encoded, with percent signs escaped
+before path separators so literal escape-looking text cannot collide.
+"""
+
+from __future__ import annotations
+
+
+def encode_skill_name_segment(skill_name: str) -> str:
+    """Return one collision-safe path component for a semantic skill name."""
+    return (
+        skill_name.replace("%", "%25")
+        .replace("/", "%2F")
+        .replace("\\", "%5C")
+    )

--- a/src/everos/infra/persistence/markdown/skill_path.py
+++ b/src/everos/infra/persistence/markdown/skill_path.py
@@ -10,8 +10,4 @@ from __future__ import annotations
 
 def encode_skill_name_segment(skill_name: str) -> str:
     """Return one collision-safe path component for a semantic skill name."""
-    return (
-        skill_name.replace("%", "%25")
-        .replace("/", "%2F")
-        .replace("\\", "%5C")
-    )
+    return skill_name.replace("%", "%25").replace("/", "%2F").replace("\\", "%5C")

--- a/src/everos/infra/persistence/markdown/writers/agent_skill_writer.py
+++ b/src/everos/infra/persistence/markdown/writers/agent_skill_writer.py
@@ -30,6 +30,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from everos.core.persistence import MarkdownWriter, MemoryRoot
+from everos.infra.persistence.markdown.skill_path import (
+    encode_skill_name_segment,
+)
 
 from ..mds import AgentSkillFrontmatter
 
@@ -157,7 +160,10 @@ class AgentSkillWriter:
             self._root.agents_dir(app_id, project_id)
             / agent_id
             / AgentSkillFrontmatter.SKILLS_CONTAINER_NAME
-            / f"{AgentSkillFrontmatter.SKILL_DIR_PREFIX}{skill_name}"
+            / (
+                f"{AgentSkillFrontmatter.SKILL_DIR_PREFIX}"
+                f"{encode_skill_name_segment(skill_name)}"
+            )
         )
 
     def _main_path(

--- a/tests/unit/test_infra/test_markdown/test_readers/test_agent_skill_reader.py
+++ b/tests/unit/test_infra/test_markdown/test_readers/test_agent_skill_reader.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from everos.core.persistence import MemoryRoot
+from everos.core.persistence import MarkdownWriter, MemoryRoot
 from everos.infra.persistence.markdown import (
     AgentSkillFrontmatter,
     AgentSkillReader,
@@ -127,3 +127,31 @@ async def test_read_script_round_trip(
 
 async def test_read_script_returns_none_when_missing(reader: AgentSkillReader) -> None:
     assert await reader.read_script("agent_x", "alpha", "ghost.py") is None
+
+
+async def test_reader_resolves_encoded_directory_from_original_name(
+    root: MemoryRoot, reader: AgentSkillReader
+) -> None:
+    name = "SDK/API verification"
+    fm = _make_fm(name=name)
+    encoded_dir = (
+        root.agents_dir() / "agent_x" / "skills" / "skill_SDK%2FAPI verification"
+    )
+    markdown_writer = MarkdownWriter(root)
+    await markdown_writer.write_markdown(
+        encoded_dir / "SKILL.md",
+        frontmatter=fm.model_dump(exclude_none=False),
+        body="Verify SDK APIs.\n",
+    )
+    await markdown_writer.write(
+        encoded_dir / "references" / "types.md", "Type definitions\n"
+    )
+    await markdown_writer.write(encoded_dir / "scripts" / "verify.py", "print('ok')\n")
+
+    main = await reader.read_main("agent_x", name, schema=AgentSkillFrontmatter)
+    assert main is not None
+    frontmatter, body = main
+    assert frontmatter.name == name
+    assert body == "Verify SDK APIs."
+    assert await reader.read_reference("agent_x", name, "types") == "Type definitions"
+    assert await reader.read_script("agent_x", name, "verify.py") == "print('ok')"

--- a/tests/unit/test_infra/test_markdown/test_skill_path.py
+++ b/tests/unit/test_infra/test_markdown/test_skill_path.py
@@ -1,0 +1,31 @@
+"""Tests for semantic skill name to filesystem-component encoding."""
+
+from __future__ import annotations
+
+import pytest
+
+from everos.infra.persistence.markdown.skill_path import (
+    encode_skill_name_segment,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("alpha", "alpha"),
+        ("API verification", "API verification"),
+        ("平台实例判定", "平台实例判定"),
+        ("框架/平台/实例", "框架%2F平台%2F实例"),
+        (r"SDK\API", "SDK%5CAPI"),
+        ("literal%2Fname", "literal%252Fname"),
+        (r"50%/SDK\API", "50%25%2FSDK%5CAPI"),
+    ],
+)
+def test_encode_skill_name_segment(name: str, expected: str) -> None:
+    assert encode_skill_name_segment(name) == expected
+
+
+def test_encoding_is_collision_safe_for_literal_escape_text() -> None:
+    assert encode_skill_name_segment("a/b") == "a%2Fb"
+    assert encode_skill_name_segment("a%2Fb") == "a%252Fb"
+    assert encode_skill_name_segment("a/b") != encode_skill_name_segment("a%2Fb")

--- a/tests/unit/test_infra/test_markdown/test_writers/test_agent_skill_writer.py
+++ b/tests/unit/test_infra/test_markdown/test_writers/test_agent_skill_writer.py
@@ -145,3 +145,47 @@ async def test_write_main_normalises_trailing_newline(
         root.agents_dir() / "agent_x" / "skills" / "skill_alpha" / "SKILL.md"
     ).read_text(encoding="utf-8")
     assert text.endswith("no-newline-end\n")
+
+
+async def test_write_main_encodes_separator_without_changing_frontmatter(
+    root: MemoryRoot, writer: AgentSkillWriter
+) -> None:
+    name = "SDK/API verification"
+    fm = _make_fm(name=name)
+    path = await writer.write_main(
+        "agent_x", name, frontmatter=fm, body="Verify SDK APIs."
+    )
+    expected = (
+        root.agents_dir()
+        / "agent_x"
+        / "skills"
+        / "skill_SDK%2FAPI verification"
+        / "SKILL.md"
+    )
+    assert path == expected
+    assert expected.is_file()
+    assert not (
+        root.agents_dir()
+        / "agent_x"
+        / "skills"
+        / "skill_SDK"
+        / "API verification"
+        / "SKILL.md"
+    ).exists()
+    parsed = await MarkdownReader.read(expected)
+    assert parsed.frontmatter["name"] == name
+
+
+async def test_write_attachments_share_encoded_skill_directory(
+    root: MemoryRoot, writer: AgentSkillWriter
+) -> None:
+    name = r"SDK/API\verification"
+    reference = await writer.write_reference(
+        "agent_x", name, "types", "Type definitions"
+    )
+    script = await writer.write_script("agent_x", name, "verify.py", "print('ok')")
+    expected_dir = (
+        root.agents_dir() / "agent_x" / "skills" / "skill_SDK%2FAPI%5Cverification"
+    )
+    assert reference == expected_dir / "references" / "types.md"
+    assert script == expected_dir / "scripts" / "verify.py"

--- a/tests/unit/test_memory/test_cascade/test_registry.py
+++ b/tests/unit/test_memory/test_cascade/test_registry.py
@@ -37,6 +37,11 @@ from everos.memory.cascade import KIND_REGISTRY, match_kind
             "default_app/default_project/agents/a1/skills/skill_contract_risk_scan/SKILL.md",
             "agent_skill",
         ),
+        (
+            "default_app/default_project/agents/a1/skills/"
+            "skill_SDK%2FAPI verification/SKILL.md",
+            "agent_skill",
+        ),
     ],
 )
 def test_match_kind_recognises_registered_paths(path: str, expected_kind: str) -> None:
@@ -54,6 +59,10 @@ def test_match_kind_recognises_registered_paths(path: str, expected_kind: str) -
         ".cache/foo.md",
         "users/u1/episodes/episode-2026-05-14.md.swp",  # swap file
         "agents/a1/skills/skill_x/references/notes.md",  # reference, not main
+        (
+            "default_app/default_project/agents/a1/skills/"
+            "skill_SDK/API verification/SKILL.md"
+        ),
         # Valid episode shape but MISSING the <app>/<project> prefix — must be
         # rejected so a prefix-less path can never silently match (the scanner
         # would otherwise find nothing while the watcher matched, a split brain).


### PR DESCRIPTION
## What changed

Agent skill names are semantic values and may contain path separators. This
patch encodes only the filesystem component, shares the mapping between the
writer and reader, and preserves Cascade's one-directory layout contract.

The frontmatter name and indexed semantic value remain unchanged. Existing
separator-free skill paths remain byte-for-byte compatible.

## Root cause

The writer previously concatenated an LLM-generated `skill.name` directly into
a directory path. `/` and `\` could therefore create nested directories, while
Cascade only recognizes a single `skill_*/SKILL.md` directory level.

## Validation

- `make ci`: passed
- Unit tests: 1513 passed
- Integration tests: 78 passed, 6 deselected
- Package build and wheel import smoke test: passed
- Conventional commit check: passed
- Public-tree and complete-diff privacy scan: no newly introduced sensitive
  matches

Tests cover separator encoding, literal-percent collision safety, writer
attachments, reader round-trips, and Cascade path recognition/rejection.
