### PR TITLE
fix(deps): pin lancedb to >=0.34.0,<0.35.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,12 @@ dependencies = [
     "pydantic-settings>=2.0.0",
 
     # Storage stack (md-first three-piece set)
-    "lancedb>=0.13.0",            # Vector + BM25 + scalar filter (Arrow-based)
+    # Upper bound: 0.35.0 embeds lance-rust v9 (large storage/encoding jump, not
+    # yet stable-released). 0.32-0.34 carry a compaction offset-overflow regression
+    # (lance-format/lance#7653); we run 0.34.0 safely via the with_position=False
+    # FTS workaround. Do not float past 0.34.x until 0.35 is validated by the soak
+    # harness. Never widen this floor back below 0.34 (older lance can't read v8 data).
+    "lancedb>=0.34.0,<0.35.0",    # Vector + BM25 + scalar filter (Arrow-based)
     "aiosqlite>=0.20.0",          # Async SQLite driver (used by SA async engine)
     "sqlmodel>=0.0.22",           # ORM (Pydantic + SQLAlchemy 2.0 async)
     "alembic>=1.13.0",            # SQLite schema migrations

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "greenlet", specifier = ">=3.0" },
     { name = "jieba", specifier = ">=0.42.1,<1.0" },
-    { name = "lancedb", specifier = ">=0.13.0" },
+    { name = "lancedb", specifier = ">=0.34.0,<0.35.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27.0" },


### PR DESCRIPTION
## Summary

Tightens the `lancedb` dependency from the open-ended `>=0.13.0` to
`>=0.34.0,<0.35.0`.

The unbounded floor let any environment resolve to an untested lancedb
release. Versions **0.32.0 → 0.34.0** embed lance-rust v6/v7/v8, which
carry a compaction offset-overflow regression
([lance-format/lance#7653](https://github.com/lance-format/lance/issues/7653)):
`optimize()` crashes while merging an unindexed tail of a `with_position`
FTS index, which stalls version cleanup and grows the index directory
without bound (observed 344 GB from ~24k rows on a user deployment).

- **Floor `0.34.0`** — the currently-resolved version. We run it safely
  via the `with_position=False` FTS workaround shipped in #336. Pinning
  the floor here prevents silently dropping back to a version without
  that mitigation.
- **Ceiling `<0.35.0`** — 0.35 embeds lance-rust v9 (the branch that
  actually fixes #7653 upstream via lance#7546), but v9 is a large
  encoding jump and has no stable release yet (0.35.0b2 is GitHub-release
  only, not on PyPI). We gate the upgrade behind a soak-test harness
  rather than floating onto it blindly.

Resolved version is **unchanged** (still `0.34.0`); this only tightens the
declared constraint and its `uv.lock` specifier.

## Area

- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [ ] Developer experience
- [x] CI, build, or release

## Verification

```text
# Constraint resolves + installs cleanly, resolved version unchanged
$ uv lock            # lancedb specifier -> >=0.34.0,<0.35.0 ; resolved 0.34.0
$ uv sync            # OK
$ python -c "import everos, lancedb; print(lancedb.__version__)"  # everos OK; 0.34.0
$ make lint          # import-linter contracts KEPT; datetime clean; openapi matches

# Cross-version read compatibility (upgrade direction is safe: new reader / old data)
# wrote 3000 rows (1024-dim vector + with_position=True FTS) under lancedb 0.32.0 (lance v6),
# then opened + counted + vector-searched + FTS-searched under 0.34.0 (lance v8):
WRITE lancedb 0.32.0  rows 3000
READ  lancedb 0.34.0  count 3000
vector-search ok, got 3
fts-search   ok, got 3
# => existing 0.32/0.33 deployments upgrade to 0.34.0 without a rebuild.
```

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed. (No runtime behavior change; the rationale is documented inline in `pyproject.toml`.)
- [ ] I added or updated tests when the change affects behavior. (Metadata-only change, no runtime behavior; cross-version compatibility verified manually — see Verification.)
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

- The `<0.35.0` ceiling is deliberate and should not be relaxed until the
  soak harness validates 0.35.x. The inline comment in `pyproject.toml`
  records the rationale so a future dependency bump doesn't silently undo it.
- Do **not** widen the floor back below `0.34`: older lance (v4, ≤0.30.2)
  cannot read v8-format data written by 0.34, so a downgrade would break
  existing indexes (rebuild-from-md required). The upgrade direction is the
  safe one, as verified above.

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.
