### PR TITLE
chore: add EverMind-AI/plugins as a submodule at plugins/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins"]
+	path = plugins
+	url = https://github.com/EverMind-AI/plugins.git

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -38,6 +38,19 @@ make help         # list every target
 CI runs the **same** `make` targets, so a green `make ci` locally predicts a
 green pipeline.
 
+### Submodules
+
+Agent-host plugins live in [EverMind-AI/plugins](https://github.com/EverMind-AI/plugins),
+referenced as a git submodule at `plugins/`. A plain clone leaves that directory
+empty — populate it once with:
+
+```bash
+git submodule update --init   # or clone with: git clone --recurse-submodules
+```
+
+The submodule is pinned to a specific commit; it is not needed for Python
+development or `make ci`, which never touch `plugins/`.
+
 ### Configuration
 
 Settings load in ascending priority:

--- a/docs/github-sync.md
+++ b/docs/github-sync.md
@@ -31,6 +31,9 @@ community-facing text). Keep the GitHub versions:
 
 ### Workflow & CI
 
+- `.gitmodules` + the `plugins` gitlink — GitHub-only submodule reference to
+  [EverMind-AI/plugins](https://github.com/EverMind-AI/plugins); an archive
+  refresh must not delete or overwrite them
 - `CLAUDE.md` — says `main` branch, not `dev`/`master`
 - `CONTRIBUTING.md` — says "curated PR contributions", not "no external PRs"
 - `.github/PULL_REQUEST_TEMPLATE.md` — GitHub PR template

--- a/scripts/check_cjk.py
+++ b/scripts/check_cjk.py
@@ -47,7 +47,10 @@ def _is_allowlisted(path: str) -> bool:
 
 def _tracked_files() -> list[str]:
     out = subprocess.check_output(["git", "ls-files"], text=True)
-    return out.splitlines()
+    # `git ls-files` also lists submodule gitlinks (e.g. `plugins`) — directories
+    # on disk, or absent entirely in a clone without --recurse-submodules. The
+    # scanner reads regular files only.
+    return [line for line in out.splitlines() if os.path.isfile(line)]
 
 
 def main() -> int:

--- a/scripts/check_deprecated_names.py
+++ b/scripts/check_deprecated_names.py
@@ -53,7 +53,11 @@ def _tracked_paths() -> list[Path]:
         stdout=subprocess.PIPE,
         text=False,
     )
-    return [Path(raw.decode("utf-8")) for raw in result.stdout.split(b"\0") if raw]
+    paths = (Path(raw.decode("utf-8")) for raw in result.stdout.split(b"\0") if raw)
+    # `git ls-files` also lists submodule gitlinks (e.g. `plugins`) — directories
+    # on disk, or absent entirely in a clone without --recurse-submodules. The
+    # guard scans regular files only.
+    return [path for path in paths if path.is_file()]
 
 
 def _tracked_text_files() -> Iterable[tuple[str, str]]:

--- a/scripts/check_repo_assets.py
+++ b/scripts/check_repo_assets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 BLOCKED_DIR_NAMES = frozenset(
     {
@@ -93,7 +93,11 @@ def _tracked_paths() -> list[str]:
         stdout=subprocess.PIPE,
         text=False,
     )
-    return [raw.decode("utf-8") for raw in result.stdout.split(b"\0") if raw]
+    names = (raw.decode("utf-8") for raw in result.stdout.split(b"\0") if raw)
+    # `git ls-files` also lists submodule gitlinks (e.g. `plugins`) — directories
+    # on disk, or absent entirely in a clone without --recurse-submodules. The
+    # guard checks regular files only.
+    return [name for name in names if Path(name).is_file()]
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Registers [EverMind-AI/plugins](https://github.com/EverMind-AI/plugins) — the
agent-host plugin monorepo (currently the OpenClaw memory plugin, published as
`@evermind-ai/openclaw-plugin` on npm) — as a git submodule at `plugins/`,
pinned to its merged `main` (`016d9eb`). EverOS gains only a pointer:
`.gitmodules` plus the gitlink; no plugin files enter this repo.

Adding the gitlink surfaced a small pre-existing fragility: the three guard
scripts that enumerate tracked files (`check_deprecated_names.py`,
`check_cjk.py`, `check_repo_assets.py`) crashed with `IsADirectoryError`,
because `git ls-files` lists a submodule's gitlink as a path while on disk it
is a directory — or absent entirely in a clone made without
`--recurse-submodules`. They now filter to regular files.

Docs updated in the same change: a "Submodules" note in `docs/engineering.md`
(`git submodule update --init` after cloning) and `.gitmodules` added to the
preserve list in `docs/github-sync.md`.

## Area

- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [x] Developer experience
- [x] CI, build, or release

## Verification

```text
make lint                  # green (includes the three fixed guard scripts)
make test                  # 1499 passed — incl. test_real_repo_has_no_deprecated_names,
                           # which failed with IsADirectoryError before the fix
git submodule status       # 016d9eb... plugins (heads/main)
```
`make integration` not run — the change touches no Python runtime code.
GitHub Actions is unaffected either way: `actions/checkout` does not fetch
submodules by default, and no CI step reads `plugins/`.

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [x] I added or updated tests when the change affects behavior.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

- After merging, existing clones need a one-time `git submodule update --init`;
  the `plugins/` directory is otherwise empty. Day-to-day Python work never
  needs the submodule populated.
- Updating the plugin later = a one-line PR moving the gitlink pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.
