### PR TITLE
docs(readme): remove Star us section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 - [Quick Start](#quick-start)
 - [Use Cases](#use-cases)
 - [Documentation](#documentation)
-- [Star Us](#star-us)
 - [EverMind Ecosystems](#evermind-ecosystems)
 - [Contributing](#contributing)
 
@@ -648,23 +647,6 @@ Explore stored entities and relationships in a graph interface. Frontend demo; b
 - [docs/migration-to-1.0.0.md](docs/migration-to-1.0.0.md) — Legacy API migration notes
 - [CHANGELOG.md](CHANGELOG.md) — Release notes
 - [CONTRIBUTING.md](CONTRIBUTING.md) — How to contribute
-
-<br>
-<div align="right">
-
-[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
-
-</div>
-
-## Star Us
-
-If EverOS is useful to your agent stack, please star the repo. It helps more
-builders discover the project and gives the memory ecosystem a stronger signal
-to keep improving.
-
-### Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=EverMind-AI/EverOS&type=Date)](https://www.star-history.com/#EverMind-AI/EverOS&Date)
 
 <br>
 <div align="right">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,6 @@
 - [快速开始](#快速开始)
 - [使用场景](#使用场景)
 - [文档](#文档)
-- [Star 支持](#star-支持)
 - [EverMind 生态](#evermind-生态)
 - [参与贡献](#参与贡献)
 
@@ -657,22 +656,6 @@ Claude Code 的持久记忆插件。自动保存并回忆过去 coding sessions 
 - [docs/migration-to-1.0.0.md](docs/migration-to-1.0.0.md) - Legacy API 迁移说明
 - [CHANGELOG.md](CHANGELOG.md) - 发布记录
 - [CONTRIBUTING.md](CONTRIBUTING.md) - 如何贡献
-
-<br>
-<div align="right">
-
-[![](https://img.shields.io/badge/-Back_to_top-gray?style=flat-square)](#readme-top)
-
-</div>
-
-## Star 支持
-
-如果 EverOS 对你的 Agent stack 有帮助，请 Star 这个仓库。它会帮助更多
-builders 发现这个项目，也会给 memory ecosystem 一个更强的信号，让它持续改进。
-
-### Star 趋势
-
-[![Star 趋势图](https://api.star-history.com/svg?repos=EverMind-AI/EverOS&type=Date)](https://www.star-history.com/#EverMind-AI/EverOS&Date)
 
 <br>
 <div align="right">


### PR DESCRIPTION
## Summary

- remove the unavailable Star History section from the English README
- remove the matching Star support section from the Chinese README
- remove both sections from their tables of contents

## Area

- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [x] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

```text
make docs-check
make ci
```

- `make docs-check`: passed
- `make ci`: passed (1585 unit tests; 79 integration tests, 6 deselected; package smoke test)

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [x] Tests were not added because this change only removes human-readable README content; existing documentation and CI checks cover the affected files.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

The local untracked `PRODUCT.md` file was intentionally excluded from this PR.

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.