### PR TITLE
test(conftest): pin EVEROS_ROOT so tests ignore the developer's config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,23 @@ _LONG_CONV_PATH = _FIXTURE_DIR / "long_conversation_locomo_caroline_melanie.json
 
 
 @pytest.fixture(autouse=True)
+def _isolate_everos_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Pin ``EVEROS_ROOT`` so no test reads the developer's own ``everos.toml``.
+
+    ``Settings`` resolves its TOML source through ``resolve_root()``, so any
+    field a test does not pass explicitly is filled from the real config file
+    on the machine running the suite. A developer who has, say, enabled
+    ``[observability]`` locally then sees failures in tests that assert the
+    default-off behaviour — green in CI, red on their machine, and unrelated to
+    whatever they were changing.
+
+    Tests that exercise root resolution itself override this: their own
+    ``setenv`` / ``delenv`` runs inside the test body, after this fixture.
+    """
+    monkeypatch.setenv("EVEROS_ROOT", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
 def _reset_settings_cache() -> Iterator[None]:
     import structlog
 


### PR DESCRIPTION
## Problem

`Settings` resolves its TOML source through `resolve_root()` (`EVEROS_ROOT` env, else `~/.everos`). Pydantic-settings fills any field the caller does not pass from that file, so a unit test constructing `Settings(llm=...)` silently inherits the rest of its configuration from **whatever the developer happens to have in `~/.everos/everos.toml`**.

Concretely: enable `[observability]` locally and `tests/unit/test_component/test_llm/test_client.py::test_returns_singleton_when_configured` starts failing, because `get_llm_client` wraps the client in `UsageRecordingClient` when tracing is on and the test asserts the unwrapped shape. CI has no `~/.everos`, so it stays green there. The failure points at a file the developer never touched, which costs real time to chase.

Other fields leak the same way — `memorize.mode`, model names, api keys — so this is a class of failure, not one test.

Three test modules already work around it individually (`test_settings.py`, `test_observability_settings.py`, `test_memory_root.py` pass `_everos_root` or set the env var), while 31 unit-test modules construct `Settings(...)` without any isolation.

## Change

One autouse fixture in `tests/conftest.py` points `EVEROS_ROOT` at a per-test `tmp_path`.

No existing test needed changing: the ones that exercise root resolution itself (`test_default_returns_home_everos`, `test_resolve_root_default`) call `monkeypatch.delenv("EVEROS_ROOT")` inside the test body, which runs after the fixture and still wins. They assert paths rather than config values, so pointing the root elsewhere first is harmless.

## Testing

`tests/unit` — 1602 passed **with `observability.enabled = true` left in the local `~/.everos/everos.toml`**, which is the configuration that reproduced the failure before this change. Lint gates (ruff check/format, import-linter, repo assets, deprecated names, datetime discipline) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyKinsWs1MgoARPoB9R4NW