### PR TITLE
docs(changelog): state the 1.2.0 regression and CWE-22 affected range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,11 +101,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **1.1.4 fixes backfilled into `main`** — the internal release lane's
-  fixes (knowledge upload path traversal / CWE-22, cascade retry
-  classification + total-retry budget, delete/modify race, embedding
-  empty-data guard, episode extraction retries) were merged back into
-  the public `main` branch so subsequent releases build on top of them.
+- **Fixes present in `1.1.4` but missing from `1.2.0`** — cascade retry
+  classification + total-retry budget, the delete/modify race, the
+  embedding empty-data guard, and episode extraction retries (each
+  detailed under 1.1.4) were absent from the branch `1.2.0` was built
+  from, so `1.2.0` regressed to pre-1.1.4 behaviour on all of them. See
+  Security below for the path traversal.
 - **Filename validation on knowledge upload** — NUL byte and > 255-byte
   UTF-8 filenames now fail fast with `InvalidInputError → HTTP 400`
   instead of surfacing OS errors as 500 with a half-written md file.
@@ -123,7 +124,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **README "Star us" section** — cleanup.
 
+### Security
+
+- **Knowledge upload path traversal (CWE-22)** — see the 1.1.4 entry for
+  the fix description. **Affected:** every release before `1.1.4`, and
+  `1.2.0`. **Not affected:** `1.1.4`. **Fixed in:** `1.2.1`. The fix
+  shipped in `1.1.4` but was not present on the branch `1.2.0` was built
+  from, so upgrading `1.1.4` → `1.2.0` reintroduced it.
+
 ## [1.2.0] - 2026-07-24
+
+> This release is missing fixes that shipped in `1.1.4`, including a
+> knowledge-upload path traversal (CWE-22). See the Security section
+> under 1.2.1 for the affected-version range.
 
 ### Added
 


### PR DESCRIPTION
## Summary

The rewritten 1.1.4 section now documents the code shipped as `everos==1.1.4`
on PyPI, which correctly lists the knowledge-upload path traversal (CWE-22) as
fixed. Read top-down, however, that leaves a **1.2.0** reader concluding the fix
predates their version and they are therefore safe — the opposite of the truth.
`1.2.0` was built from a branch that never received those fixes, so it regressed
to pre-1.1.4 behaviour, and the changelog says so nowhere.

Three changes, no history rewritten:

1. The 1.2.1 `Fixed` entry now names what `1.2.0` regressed, instead of
   describing the merge as internal branch hygiene ("backfilled into `main` …
   so subsequent releases build on top of them"), which tells a user nothing
   about their own exposure.
2. A `Security` section under 1.2.1 carries the affected-version range. The
   range is **discontinuous** — everything before `1.1.4`, plus `1.2.0`; `1.1.4`
   itself is not affected — so it cannot be inferred from "fixed in 1.2.1".
3. A one-line note under 1.2.0 points forward, covering the reader who looks up
   the version they are running rather than the newest one.

This brings `CHANGELOG.md` in line with the published
[v1.2.1 release notes](https://github.com/EverMind-AI/EverOS/releases/tag/v1.2.1),
which already carry the same Security block.

## Area

- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [x] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

```text
Affected-version range verified against the published artifacts, not inferred —
each sdist downloaded from PyPI and _write_original_file inspected:

  everos 1.1.4  -> _safe_original_filename + resolve().is_relative_to  present
  everos 1.2.0  -> target = original_dir / source_name, no validation  ABSENT
  everos 1.2.1  -> containment present

python3 scripts/check_commit_messages.py HEAD^..HEAD  -> pass
No line in the diff exceeds 80 columns (matches surrounding style).
Documentation-only change; no code or tests affected.
```

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [x] I added or updated tests when the change affects behavior. (N/A — docs only)
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

Worth deciding explicitly: **should this also be a GitHub Security Advisory?**
Right now the only public statement of the `1.2.0` exposure is this changelog
entry plus the v1.2.1 release notes. Without a GHSA, Dependabot will not notify
anyone still running `1.2.0`. The repository has one prior advisory,
`GHSA-c795-2g9c-j48m`, for the sibling `sender_id` traversal — same class, same
containment approach — so there is precedent for filing one here.

If a GHSA is filed, the affected range needs both segments (`< 1.1.4` and
`= 1.2.0`); collapsing it to `< 1.2.1` would incorrectly flag `1.2.0` as the
only safe pre-fix release... and would wrongly mark `1.1.4` users as vulnerable.

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.
