### PR TITLE
fix(strategies): guard foresight sender scan against tool-call items

### DIFF
--- a/src/everos/memory/strategies/extract_foresight.py
+++ b/src/everos/memory/strategies/extract_foresight.py
@@ -49,9 +49,16 @@ def _get_writer() -> ForesightWriter:
     max_retries=2,
 )
 async def extract_foresight(event: UserPipelineStarted, ctx: StrategyContext) -> None:
-    # 1. List the user senders in this memcell.
+    # 1. List the user senders in this memcell. A memcell cut from an agent
+    #    trajectory also holds ToolCallRequest / ToolCallResult items, which
+    #    carry no ``role`` — bare attribute access raised AttributeError and
+    #    took the strategy down for any session containing a tool call. Guarded
+    #    the same way as the sibling scans in ``extract/pipeline/user_memory``
+    #    and ``service/_boundary``.
     memcell = event.memcell
-    sender_ids = sorted({m.sender_id for m in memcell.items if m.role == "user"})
+    sender_ids = sorted(
+        {m.sender_id for m in memcell.items if getattr(m, "role", None) == "user"}
+    )
     extractor = ForesightExtractor(llm=get_llm_client()) if sender_ids else None
 
     # 2. Run the LLM extractor once per sender (prompt is per-sender).

--- a/tests/unit/test_memory/test_strategies/test_extract_foresight.py
+++ b/tests/unit/test_memory/test_strategies/test_extract_foresight.py
@@ -5,7 +5,15 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import structlog.testing
-from everalgo.types import ChatMessage, Foresight, MemCell
+from everalgo.types import (
+    ChatMessage,
+    Foresight,
+    MemCell,
+    ToolCall,
+    ToolCallFunction,
+    ToolCallRequest,
+    ToolCallResult,
+)
 
 from everos.infra.ome.testing import FakeStrategyContext
 from everos.memory.events import UserPipelineStarted
@@ -195,6 +203,69 @@ async def test_writes_md_for_each_foresight(
     assert inline1["start_time"] == "2023-11-15"
     assert inline1["duration_days"] == 7
     assert sections1 == {"Foresight": "buy tickets", "Evidence": "confirmed"}
+
+
+async def test_survives_tool_call_items_in_the_memcell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An agent trajectory puts ToolCallRequest / ToolCallResult items on the
+    memcell. Those carry no ``role``, so reading it unguarded took the whole
+    strategy down for any session containing a tool call."""
+    memcell = MemCell(
+        items=[
+            ChatMessage(
+                id="m1",
+                role="user",
+                content="why is the proof not rising",
+                timestamp=1_700_000_000_000,
+                sender_id="u_alice",
+            ),
+            ToolCallRequest(
+                tool_calls=[
+                    ToolCall(
+                        id="c1",
+                        function=ToolCallFunction(
+                            name="get_room_temperature", arguments="{}"
+                        ),
+                    )
+                ],
+                content="checking the kitchen",
+                timestamp=1_700_000_001_000,
+                sender_id="kitchen-helper",
+            ),
+            ToolCallResult(
+                tool_call_id="c1",
+                content='{"avg_c": 16.2}',
+                timestamp=1_700_000_002_000,
+            ),
+        ],
+        timestamp=1_700_000_002_000,
+    )
+    event = UserPipelineStarted(memcell_id="mc_tools", session_id="s1", memcell=memcell)
+
+    monkeypatch.setattr(mod, "_writer", None, raising=False)
+    with (
+        patch(
+            "everos.memory.strategies.extract_foresight.get_llm_client",
+            return_value=object(),
+        ),
+        patch(
+            "everos.memory.strategies.extract_foresight.ForesightExtractor"
+        ) as mock_cls,
+        patch(
+            "everos.memory.strategies.extract_foresight.ForesightWriter"
+        ) as mock_wcls,
+    ):
+        mock_cls.return_value.aextract = AsyncMock(
+            return_value=[_foresight("u_alice", "will bake again")]
+        )
+        mock_wcls.return_value.append_entries = AsyncMock(return_value=["fs_1"])
+        ctx = FakeStrategyContext()
+        await extract_foresight(event, ctx)
+
+    # The one user ChatMessage is still found; the tool items are ignored.
+    mock_cls.return_value.aextract.assert_awaited_once()
+    assert mock_cls.return_value.aextract.await_args.kwargs["sender_id"] == "u_alice"
 
 
 async def test_skips_when_memcell_has_no_messages(


### PR DESCRIPTION
## Problem

`extract_foresight` opens by listing the user senders in the memcell:

```python
sender_ids = sorted({m.sender_id for m in memcell.items if m.role == "user"})
```

`memcell.items` is a union. Only `ChatMessage` carries a `role`; `ToolCallRequest` has a sender but no role, and `ToolCallResult` has neither. So a memcell cut from an agent trajectory raises `AttributeError: 'ToolCallRequest' object has no attribute 'role'` on the first tool item, and the strategy dies before it extracts anything. **Every session containing a tool call loses foresights for all of its users.**

Found while recording a Langfuse trace fixture against 1.2.1: a four-round agent trajectory produced three `everos.ome.extract_foresight` error spans, one per retry.

## Change

Guard the attribute read with `getattr`, matching how the rest of the codebase already walks this union:

| call site | existing guard |
| --- | --- |
| `extract/pipeline/user_memory.py:230` | `getattr(item, "role", None) != "user"` — same job, collecting user senders |
| `extract_agent_case.py:131` | `getattr(item, "sender_id"/"role"/"kind", None)` |
| `service/_boundary.py:467` | `getattr(item, "sender_id", None)` |

`extract_foresight.py:54` was the only unguarded read left, so this completes the pattern rather than introducing a new one.

Semantics are unchanged: a tool call is issued by an agent, so its `sender_id` could never be a user sender, and `ToolCallResult` has no sender at all. The set of user senders is exactly the set of `role == "user"` chat messages either way.

## Why the extractor needs no change

`ForesightExtractor` is already designed to accept an agent-shaped memcell — its docstring states that *non-ChatMessage items in memcell.items are silently skipped (agent → user-memory contract)*, and it filters internally through everalgo's own `chat_messages()` helper. The crash was purely in our pre-scan, so the fix does not just move the failure one line down.

That helper is deliberately not imported here: it lives in `everalgo/user_memory/_render.py`, whose module docstring marks it internal and outside the public API.

## Testing

New regression test builds a memcell with a `ChatMessage` plus `ToolCallRequest` / `ToolCallResult` and asserts the strategy still finds the one user sender. It fails with `AttributeError` against the unpatched line and passes with the guard.

`tests/unit` 1862 passed; ruff check/format, import-linter and the repo gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyKinsWs1MgoARPoB9R4NW