### PR TITLE
feat(examples): zero-install Langfuse replay + a demo memory worth searching

### DIFF
--- a/examples/langfuse/README.md
+++ b/examples/langfuse/README.md
@@ -6,7 +6,50 @@ reflection — and exports them over OTLP to any backend, including
 [Langfuse](https://langfuse.com). There is **no wrapper and no extra
 instrumentation code**: enable it in config and the traces appear.
 
-## Enable
+Two ways to look at it:
+
+| | What it is | What you need |
+| --- | --- | --- |
+| [Replay a recording](#replay-a-recording-no-everos-needed) | A trace a real EverOS server produced, pushed into your Langfuse project | Langfuse keys only |
+| [Trace your own server](#trace-your-own-server) | Your EverOS, your data, live | An EverOS server |
+
+## Replay a recording (no EverOS needed)
+
+`recorded_trace.json` is a capture of one real `demo.py` run against EverOS
+1.2.1: 237 spans over 60 traces. Eleven conversations are ingested and flushed,
+each with its LLM extraction and OME strategies nested underneath; reflection
+then consolidates two of them and deprecates what they superseded; and five
+questions are asked of the resulting memory, with their recall scores.
+`replay.py` pushes it into your own Langfuse project, so you can see what the
+integration looks like before deploying anything.
+
+```bash
+pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+export LANGFUSE_HOST="https://cloud.langfuse.com"   # US: https://us.cloud.langfuse.com
+python replay.py
+```
+
+Then open Langfuse → **Tracing** and filter on the `replay` tag.
+
+Span names, attributes, token usage, parent/child structure and durations are
+EverOS's own output, replayed verbatim. Three things are rewritten: trace and
+span ids are minted fresh so repeated runs do not collide, timestamps are
+shifted so the trace lands at the current time, and root spans carry a `replay`
+tag so a recording is never mistaken for live traffic.
+
+Two things in the trace list are not self-explanatory. The short keyword
+searches beyond the five questions are `demo.py` waiting for each conversation
+to become searchable. And the OME spans outlast the `flush` span they hang
+under, because reflection continues after the request returns and re-attaches
+to the originating trace through its `traceparent`.
+
+Recall scores are per-method scales: read HYBRID against HYBRID, not against
+AGENTIC. Agent cases and skills are not in this recording; the span and score
+contract is the same when they appear.
+
+## Trace your own server
 
 1. Install the optional OpenTelemetry extra:
 
@@ -29,14 +72,25 @@ instrumentation code**: enable it in config and the traces appear.
    Container/CI equivalent via env vars: `EVEROS_OBSERVABILITY__ENABLED=true`,
    `EVEROS_OBSERVABILITY__LANGFUSE_PUBLIC_KEY=...`, and so on.
 
-3. Run EverOS normally:
+3. Run EverOS normally, then drive one memory lifecycle through it:
 
    ```bash
    everos server start
+   python demo.py            # add -> flush -> search against 127.0.0.1:8000
    ```
+
+   `demo.py` uses only the standard library and contains no instrumentation
+   code; the spans come from the server. It ingests eleven conversations, nudges
+   reflection (a weekly cron otherwise), then asks five questions, so the
+   traces show recall choosing between memories rather than returning the only
+   one there is.
 
 Off by default — with `enabled = false` (or the `otel` extra absent) there is
 zero tracing overhead.
+
+The signal is plain OTLP/HTTP and vendor-neutral, so the same config exports to
+an OpenTelemetry Collector or any other OTLP backend. The `langfuse_*` keys are
+just a shortcut that fills in the endpoint and auth header for you.
 
 ## What you get
 
@@ -48,7 +102,8 @@ zero tracing overhead.
 | markdown persistence | span `everos.persist.markdown` |
 | `POST /api/v2/memory/search` | retriever `everos.memory.search` → `recall` / `rank` |
 | query / recall embedding | embedding `everos.embedding` |
-| OME reflection strategies | agent `everos.ome.<strategy>` (linked to the triggering request's trace) |
+| OME extraction strategies | agent `everos.ome.<strategy>` (linked to the triggering request's trace) |
+| reflection consolidating a cluster | span `everos.reflect.consolidate` under `everos.ome.reflect_episodes` |
 
 `langfuse.session.id` / `langfuse.user.id` group the traces. Recall quality is
 pushed as Langfuse scores, split by whether the method's score is calibrated:
@@ -58,17 +113,21 @@ cosine values are on a different scale and must not be averaged in with the
 calibrated ones. Query and memory text are captured only when
 `capture_content = true`.
 
-## Try it
+## Re-recording the fixture
 
-With a server running and `[observability]` enabled:
+`record_trace.py` is the maintainer-side tool that produced
+`recorded_trace.json`. It stands in for Langfuse's two ingestion endpoints on
+localhost, so a real EverOS server exports its spans *and* its recall scores
+there instead of to Langfuse. Nothing about the recording is synthesized.
 
 ```bash
-python demo.py
+python record_trace.py     # sink on :4318; writes the fixture on Ctrl-C
 ```
 
-It drives one add → flush → search (keyword / hybrid / agentic) cycle against
-`http://127.0.0.1:8000` using only the standard library, then tells you to open
-Langfuse → **Tracing** filtered to `session.id = langfuse_demo`.
+Point `[observability].langfuse_host` at `http://127.0.0.1:4318`, start the
+server, run `demo.py`, then stop the sink. Only worth redoing when the span
+contract changes (a span added, renamed, or given new attributes); ordinary
+releases do not invalidate a recording.
 
 ## Learn more
 

--- a/examples/langfuse/demo.py
+++ b/examples/langfuse/demo.py
@@ -1,9 +1,15 @@
-"""Minimal EverOS x Langfuse demo — native OpenTelemetry tracing.
+"""EverOS x Langfuse demo — native OpenTelemetry tracing.
 
 EverOS emits OTel spans for its own memory operations when ``[observability]``
-is enabled; this script contains **no instrumentation code**. It just drives a
-running server (add -> flush -> search) so the traces the server produces show
-up in your Langfuse project.
+is enabled; this script contains **no instrumentation code**. It drives a
+running server through a memory lifecycle worth looking at in Langfuse.
+
+Eleven short conversations spread over ten weeks, each on its own topic, so
+recall has to pick the right memory out of a populated store rather than
+returning the only thing in it. Two revisit the same subject days apart (an
+October trip moves from Lisbon to Porto), close enough that geometry
+clustering groups them, which gives reflection something to consolidate. One
+query asks about something never discussed, so a miss looks like a miss.
 
 Prereqs (see README.md):
   1. pip install "everos[otel]"
@@ -17,11 +23,300 @@ from __future__ import annotations
 
 import json
 import time
+import urllib.error
 import urllib.request
 
 BASE = "http://127.0.0.1:8000"
-SESSION = "langfuse_demo"
 USER = "alice"
+DAY_MS = 86_400_000
+
+# Extraction and the SQLite -> LanceDB index sync run asynchronously, so how
+# long a memory takes to become searchable depends on the LLM behind it.
+INDEX_TIMEOUT_SECONDS = 300.0
+# Deliberately slack: every probe is itself a traced search, and polling hard
+# would bury the five real questions under a wall of readiness checks.
+INDEX_POLL_SECONDS = 10.0
+CONSOLIDATION_TIMEOUT_SECONDS = 180.0
+
+# ── the conversations ────────────────────────────────────────────────────
+# ``days_ago`` only spaces the timestamps out; every session is ingested now.
+SESSIONS: list[dict] = [
+    {
+        "id": "everos-demo-trip-booked",
+        "days_ago": 70,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "We booked the October trip: Lisbon, a week, flying out on the "
+                    "12th."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": "Noted, a week in Lisbon in October departing on the 12th.",
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-dentist",
+        "days_ago": 63,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "The dentist put a crown on my lower left molar today. Check-up in "
+                    "six months."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Recorded the crown on your lower left molar, with a check-up due "
+                    "in six months."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-trip-changed",
+        "days_ago": 65,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "October changed. We cancelled Lisbon and booked Porto instead, my "
+                    "sister moved the wedding there."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Updated, the October trip is Porto now rather than Lisbon, "
+                    "because the wedding moved."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-cello",
+        "days_ago": 49,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "I started cello lessons. My teacher is Marta, Thursdays at 19:00."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": "Cello with Marta on Thursdays at 19:00, noted.",
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-cat-allergy",
+        "days_ago": 42,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "The vet says Mochi is allergic to chicken. We switched her to the "
+                    "salmon food."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Mochi has a chicken allergy and is now on salmon food. I will "
+                    "keep chicken out of any suggestions for her."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-bike",
+        "days_ago": 35,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "Radhaus replaced the rear derailleur on my bike. They said to "
+                    "swap the chain at 3000 km."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "New rear derailleur from Radhaus, and the chain is due for a swap "
+                    "at 3000 km."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-sourdough",
+        "days_ago": 28,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "My sourdough came out flat three bakes running. The starter "
+                    "doubles by noon, so that is not it."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "The kitchen drops to about 16C overnight and the dough sat on the "
+                    "counter until morning. Bulk proofing wants 24 to 26C, so the rise "
+                    "stalled and the loaf spread instead of holding shape."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Proofed it in the oven with just the light on and it worked. Best "
+                    "crumb yet."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "The oven light holds about 24C, which fixed it. Worth keeping: "
+                    "judge proofing by the dough, not the clock, because the same "
+                    "recipe needs different hours at different temperatures."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-spare-keys",
+        "days_ago": 21,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "Tomas next door has our spare keys now. He waters the plants when "
+                    "we travel."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Tomas next door holds the spare keys and waters the plants while "
+                    "you are away."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-physio",
+        "days_ago": 14,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "Started physio for my right shoulder. Band work twice a day, and "
+                    "no overhead presses until they clear me."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Physio for the right shoulder: band exercises twice daily, and "
+                    "overhead presses are off the table until you are cleared."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-food-rules",
+        "days_ago": 8,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "When you plan meals for me, remember I am vegetarian and I "
+                    "cannot stand mushrooms. No fish either."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Recorded your food rules for meal planning: vegetarian, no "
+                    "fish, and no mushrooms in anything."
+                ),
+            },
+        ],
+    },
+    {
+        "id": "everos-demo-morning-routine",
+        "days_ago": 5,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "I run before work every morning, so breakfast ends up late, "
+                    "usually around ten."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Noted: you run before work each morning and eat breakfast "
+                    "late, around ten."
+                ),
+            },
+        ],
+    },
+]
+
+# ── the queries ──────────────────────────────────────────────────────────
+# KEYWORD is deliberately absent: its top score is raw BM25, on a different
+# scale from the calibrated methods, so showing the three side by side invites
+# a comparison that means nothing. It still runs as the readiness probe.
+QUERIES: list[dict] = [
+    {
+        "label": "history",
+        "query": (
+            "what happened with the October trip we booked, did the destination "
+            "change after the wedding moved"
+        ),
+        "note": "the plan, its revision, and whatever reflection made of them",
+    },
+    {
+        "label": "constraint",
+        "query": (
+            "what did the vet say about Mochi's allergy and which food did we "
+            "switch her to"
+        ),
+        "note": "one specific memory out of eleven conversations",
+    },
+    {
+        "label": "how-to",
+        "query": (
+            "why did my sourdough loaves keep coming out flat and what fixed "
+            "the overnight proofing"
+        ),
+        "note": "the diagnosis and the fix, not just a stated fact",
+    },
+    {
+        "label": "profile",
+        "query": (
+            "which foods should you leave out when you plan my meals, I am vegetarian"
+        ),
+        "note": "include_profile also returns the distilled profile",
+        "include_profile": True,
+    },
+    {
+        "label": "miss",
+        "query": "what did the accountant say about our tax return this year",
+        "note": "never discussed — candidates come back, the score says no",
+    },
+]
+
+METHODS = ("hybrid", "agentic")
 
 
 def _post(path: str, body: dict) -> dict:
@@ -35,57 +330,204 @@ def _post(path: str, body: dict) -> dict:
         return json.load(resp)
 
 
-def main() -> None:
-    ts = int(time.time() * 1000)
+def _search(spec: dict, method: str, *, top_k: int = 5) -> dict:
+    """Search one query across everything its owner remembers.
 
-    add = _post(
-        "/api/v2/memory/add",
+    No session filter: the point is to make recall choose between memories
+    from different conversations.
+    """
+    body: dict = {
+        "user_id": USER,
+        "query": spec["query"],
+        "method": method,
+        "top_k": top_k,
+    }
+    if spec.get("include_profile"):
+        body["include_profile"] = True
+    return _post("/api/v2/memory/search", body)
+
+
+def _wire_messages(session: dict, base_ts: int) -> list[dict]:
+    """Expand a session's (role, content) pairs into API message items."""
+    return [
         {
-            "session_id": SESSION,
-            "messages": [
-                {
-                    "message_id": "m1",
-                    "role": "user",
-                    "content": "Moved our vector store to LanceDB to fix index bloat.",
-                    "timestamp": ts,
-                    "sender_id": USER,
-                },
-                {
-                    "message_id": "m2",
-                    "role": "assistant",
-                    "content": "Noted — LanceDB with compaction keeps it compact.",
-                    "timestamp": ts + 1000,
-                    "sender_id": "assistant",
-                },
-            ],
-        },
+            "message_id": f"{session['id']}-m{index}",
+            "role": message["role"],
+            "content": message["content"],
+            "timestamp": base_ts + index * 60_000,
+            "sender_id": USER if message["role"] == "user" else "assistant",
+        }
+        for index, message in enumerate(session["messages"], start=1)
+    ]
+
+
+def _ingest(session: dict, now_ms: int) -> None:
+    base_ts = now_ms - session["days_ago"] * DAY_MS
+    messages = _wire_messages(session, base_ts)
+    add = _post(
+        "/api/v2/memory/add", {"session_id": session["id"], "messages": messages}
     )
-    print("add   ->", add["data"])
+    flush = _post("/api/v2/memory/flush", {"session_id": session["id"], "messages": []})
+    print(
+        f"  {session['id']:<30} {len(messages):>2} msgs  "
+        f"add={add['data'].get('status')} flush={flush['data'].get('status')}"
+    )
 
-    flush = _post("/api/v2/memory/flush", {"session_id": SESSION, "messages": []})
-    print("flush ->", flush["data"])
 
-    print("waiting for async index sync ...")
-    time.sleep(10)
+def _session_is_searchable(session: dict) -> bool:
+    """Keyword-probe one session with its own opening line.
 
-    for method in ("keyword", "hybrid", "agentic"):
-        resp = _post(
+    Querying the session's own words guarantees the lexical overlap BM25
+    needs, so an empty result means "not indexed yet" rather than "no match".
+    """
+    opening = next(m["content"] for m in session["messages"] if m["role"] == "user")
+    body = {
+        "user_id": USER,
+        "query": opening,
+        "method": "keyword",
+        "top_k": 1,
+        "filters": {"session_id": session["id"]},
+    }
+    return bool(_post("/api/v2/memory/search", body)["data"].get("episodes"))
+
+
+def _wait_for_index() -> list[str]:
+    """Poll until every ingested session is searchable; return any laggards.
+
+    Waiting on one session is not enough: extraction and the SQLite ->
+    LanceDB sync run per session and finish out of order, so querying too
+    early makes recall choose from a partial store and the scores read
+    lower than the memory deserves.
+    """
+    deadline = time.monotonic() + INDEX_TIMEOUT_SECONDS
+    laggards: list[str] = []
+    # One session at a time, in ingest order. Probing every pending session on
+    # every round would work too, but each probe is itself a traced search, and
+    # a hundred readiness probes would bury the five real queries in Langfuse.
+    # Extraction broadly follows ingest order, so by the time session N answers
+    # its predecessors already have.
+    for session in SESSIONS:
+        while not _session_is_searchable(session):
+            if time.monotonic() > deadline:
+                laggards.append(session["id"])
+                break
+            time.sleep(INDEX_POLL_SECONDS)
+    return laggards
+
+
+def _reflect() -> str:
+    """Run episode reflection now instead of waiting for its weekly cron.
+
+    Consolidation is what merges a cluster of related memories and deprecates
+    what they superseded, so a demo that never triggers it never shows the
+    part of EverOS that improves memory over time. ``reflect_episodes`` is
+    scheduled ``0 2 * * 1``, hence the manual nudge.
+    """
+    body = {"name": "reflect_episodes", "force": True, "timeout": 300.0}
+    return str(_post("/api/v2/ome/trigger", body)["status"])
+
+
+def _wait_for_consolidation() -> bool:
+    """Poll until the consolidated memory has replaced what it superseded.
+
+    ``/ome/trigger`` returns once the OME engine is idle, but the merge reaches
+    LanceDB through the cascade, and deprecating the old episodes is a separate
+    write from indexing the merged one. Querying in between sees neither, and
+    scores lower than the memory deserves. So wait for both edges: the first
+    trip session going unsearchable, then the merged memory answering for it.
+    """
+    superseded, survivor = SESSIONS[0], SESSIONS[2]
+    opening = next(m["content"] for m in survivor["messages"] if m["role"] == "user")
+    deadline = time.monotonic() + CONSOLIDATION_TIMEOUT_SECONDS
+
+    while time.monotonic() < deadline:
+        if not _session_is_searchable(superseded):
+            break
+        time.sleep(INDEX_POLL_SECONDS)
+    else:
+        return False
+
+    # The originals are gone; wait for the merged episode to answer in their
+    # place. No session filter: the merge is its own entry, not either source.
+    while time.monotonic() < deadline:
+        found = _post(
             "/api/v2/memory/search",
-            {
-                "user_id": USER,
-                "query": "which vector database did we move to and why",
-                "method": method,
-                "top_k": 5,
-                "filters": {"session_id": SESSION},
-            },
+            {"user_id": USER, "query": opening, "method": "keyword", "top_k": 1},
+        )["data"].get("episodes")
+        if found:
+            return True
+        time.sleep(INDEX_POLL_SECONDS)
+    return False
+
+
+def _describe(data: dict) -> str:
+    """What a search returned per memory kind, plus its best score.
+
+    The score matters more than the count: recall returns candidates up to
+    ``top_k`` whether or not they are relevant, so a query about something
+    never discussed still comes back with episodes. The top score is what
+    says they do not answer it.
+    """
+    parts = [
+        f"{len(items)} {kind.replace('_', ' ')}"
+        for kind in ("episodes", "profiles", "agent_cases", "agent_skills")
+        if (items := data.get(kind) or [])
+    ]
+    scored = [
+        item.get("score")
+        for kind in ("episodes", "agent_cases", "agent_skills")
+        for item in data.get(kind) or []
+        if item.get("score") is not None
+    ]
+    summary = ", ".join(parts) or "nothing"
+    return f"{summary:<34} top_score={max(scored):.3f}" if scored else summary
+
+
+def main() -> None:
+    now_ms = int(time.time() * 1000)
+
+    print(f"ingesting {len(SESSIONS)} sessions ...")
+    for session in SESSIONS:
+        _ingest(session, now_ms)
+
+    print("\nwaiting for async extraction + index sync ...")
+    if pending := _wait_for_index():
+        print(
+            f"  still not searchable after {INDEX_TIMEOUT_SECONDS:.0f}s: "
+            f"{', '.join(pending)}; searching anyway so you can still see "
+            "the traces"
         )
-        hits = len(resp["data"].get("episodes", []))
-        print(f"search[{method}] -> {hits} hit(s)")
+    else:
+        print(f"  all {len(SESSIONS)} sessions searchable")
+
+    print("\nrunning reflection (normally a weekly cron) ...")
+    print(f"  reflect_episodes -> {_reflect()}")
+    if _wait_for_consolidation():
+        print(f"  {SESSIONS[0]['id']} superseded and no longer searchable")
+    else:
+        print("  nothing was consolidated; the originals are both still live")
+
+    print()
+    for spec in QUERIES:
+        print(f"{spec['label']}: {spec['query']}")
+        print(f"  ({spec['note']})")
+        for method in spec.get("methods", METHODS):
+            try:
+                data = _search(spec, method)["data"]
+            except urllib.error.HTTPError as exc:
+                # Embedding and rerank are soft dependencies: with neither
+                # configured a server serves KEYWORD only, and HYBRID /
+                # AGENTIC answer 422 CAPABILITY_UNAVAILABLE. Report it and
+                # carry on so the other queries still have something to show.
+                print(f"  {method:<8} HTTP {exc.code}: {exc.reason}")
+                continue
+            print(f"  {method:<8} {_describe(data)}")
+        print()
 
     print(
-        f"\nOpen Langfuse -> Tracing and filter session.id = {SESSION} "
-        "to see the traces (add / flush / search, with token usage and "
-        "recall-quality scores)."
+        "Open Langfuse -> Tracing. Traces are grouped by session; the search "
+        "traces carry recall-quality scores, and the flush traces carry the "
+        "LLM token usage Langfuse turns into cost."
     )
 
 

--- a/examples/langfuse/record_trace.py
+++ b/examples/langfuse/record_trace.py
@@ -1,0 +1,218 @@
+"""Record a real EverOS trace into ``recorded_trace.json`` (maintainer tool).
+
+This stands in for Langfuse's two ingestion endpoints on localhost, so a real
+EverOS server exports its spans *and* its recall scores here instead of to
+Langfuse. What lands in the fixture is exactly what EverOS emitted: no span is
+synthesized, no attribute is invented. ``replay.py`` then pushes that recording
+into any reader's own Langfuse project.
+
+Both signals are captured by one sink because EverOS derives both endpoints
+from ``langfuse_host``: spans go to ``<host>/api/public/otel/v1/traces`` and
+scores to ``<host>/api/public/scores``.
+
+Usage:
+    1. Point EverOS at this sink in ``everos.toml``. Keep the LLM, embedding and
+       rerank sections filled in — a recording with real generations is the
+       point, since that is what gives Langfuse the token usage to cost out.
+
+           [observability]
+           enabled             = true
+           langfuse_public_key = "pk-lf-local"     # any value; the sink ignores auth
+           langfuse_secret_key = "sk-lf-local"
+           langfuse_host       = "http://127.0.0.1:4318"
+           capture_content     = true              # demo data is synthetic, so show it
+
+    2. ``python record_trace.py``      # starts the sink on :4318
+    3. ``everos server start``         # in another shell
+    4. ``python demo.py``              # drives add -> flush -> search
+    5. Ctrl-C the sink; it writes ``recorded_trace.json``
+
+Requires the OTel protobuf definitions, which ship with the exporter EverOS
+already needs::
+
+    pip install opentelemetry-exporter-otlp-proto-http
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import sys
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as PbSpan
+from opentelemetry.proto.trace.v1.trace_pb2 import Status as PbStatus
+
+TRACES_PATH = "/api/public/otel/v1/traces"
+SCORES_PATH = "/api/public/scores"
+
+# Collected across requests; written out on shutdown.
+_spans: list[dict[str, Any]] = []
+_scores: list[dict[str, Any]] = []
+_resource: dict[str, Any] = {}
+
+
+def _any_value(value: Any) -> Any:
+    """Decode an OTLP ``AnyValue`` into a plain Python value."""
+    which = value.WhichOneof("value")
+    if which == "array_value":
+        return [_any_value(item) for item in value.array_value.values]
+    if which == "kvlist_value":
+        return {kv.key: _any_value(kv.value) for kv in value.kvlist_value.values}
+    if which is None:
+        return None
+    return getattr(value, which)
+
+
+def _attributes(pairs: Any) -> dict[str, Any]:
+    return {kv.key: _any_value(kv.value) for kv in pairs}
+
+
+def _ingest_traces(body: bytes) -> int:
+    """Decode one OTLP export request, appending its spans to ``_spans``."""
+    global _resource
+    request = ExportTraceServiceRequest()
+    request.ParseFromString(body)
+    count = 0
+    for resource_spans in request.resource_spans:
+        if not _resource:
+            _resource = _attributes(resource_spans.resource.attributes)
+        for scope_spans in resource_spans.scope_spans:
+            for span in scope_spans.spans:
+                parent = span.parent_span_id.hex()
+                _spans.append(
+                    {
+                        "trace_id": span.trace_id.hex(),
+                        "span_id": span.span_id.hex(),
+                        "parent_span_id": parent or None,
+                        "name": span.name,
+                        "kind": PbSpan.SpanKind.Name(span.kind),
+                        "start_unix_nano": span.start_time_unix_nano,
+                        "end_unix_nano": span.end_time_unix_nano,
+                        "status": {
+                            "code": PbStatus.StatusCode.Name(span.status.code),
+                            "message": span.status.message,
+                        },
+                        "attributes": _attributes(span.attributes),
+                    }
+                )
+                count += 1
+    return count
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length") or 0)
+        body = self.rfile.read(length)
+        if self.headers.get("content-encoding") == "gzip":
+            body = gzip.decompress(body)
+        path = self.path.split("?", 1)[0]
+
+        if path == TRACES_PATH:
+            try:
+                added = _ingest_traces(body)
+            except Exception as exc:  # keep the sink alive; the export retries
+                print(f"  ! failed to decode an export: {exc}", file=sys.stderr)
+                self._respond(400, b"")
+                return
+            print(f"  spans   +{added} (total {len(_spans)})")
+            self._respond(
+                200,
+                ExportTraceServiceResponse().SerializeToString(),
+                content_type="application/x-protobuf",
+            )
+            return
+
+        if path == SCORES_PATH:
+            score = json.loads(body)
+            _scores.append(score)
+            print(
+                f"  score   {score.get('name')}={score.get('value')} "
+                f"({score.get('comment')})"
+            )
+            self._respond(201, b"{}", content_type="application/json")
+            return
+
+        self._respond(404, b"")
+
+    def _respond(
+        self, status: int, body: bytes, *, content_type: str | None = None
+    ) -> None:
+        self.send_response(status)
+        if content_type:
+            self.send_header("content-type", content_type)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def log_message(self, *args: Any) -> None:
+        """Silence the default per-request logging; we print our own summary."""
+
+
+def _write_fixture(path: str, everos_version: str | None) -> None:
+    if not _spans:
+        print("\nNothing recorded — no fixture written.", file=sys.stderr)
+        return
+    _spans.sort(key=lambda span: span["start_unix_nano"])
+    fixture = {
+        "recorded_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "everos_version": everos_version or _resource.get("service.version"),
+        "resource": _resource,
+        "spans": _spans,
+        "scores": _scores,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(fixture, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    traces = len({span["trace_id"] for span in _spans})
+    print(
+        f"\nWrote {path}: {len(_spans)} span(s) across {traces} trace(s), "
+        f"{len(_scores)} score(s)."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=4318)
+    parser.add_argument("--out", default="recorded_trace.json")
+    parser.add_argument(
+        "--everos-version",
+        default=None,
+        help="Stamped into the fixture; defaults to the exporter's "
+        "service.version resource attribute.",
+    )
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), _Handler)
+    print(
+        f"Recording on http://127.0.0.1:{args.port}\n"
+        f"  spans  <- POST {TRACES_PATH}\n"
+        f"  scores <- POST {SCORES_PATH}\n"
+        "Point everos.toml's [observability].langfuse_host at it, start the "
+        "server, run demo.py, then Ctrl-C here.\n"
+    )
+
+    # Let KeyboardInterrupt break out of serve_forever, then write the fixture on
+    # the way out. Calling server.shutdown() from a signal handler instead would
+    # deadlock: it waits for the serve_forever loop that the handler is blocking.
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopping ...")
+    finally:
+        server.server_close()
+        _write_fixture(args.out, args.everos_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langfuse/recorded_trace.json
+++ b/examples/langfuse/recorded_trace.json
@@ -1,0 +1,6451 @@
+{
+  "recorded_at": "2026-07-29T21:03:11+00:00",
+  "everos_version": "1.2.1",
+  "resource": {
+    "telemetry.sdk.language": "python",
+    "telemetry.sdk.name": "opentelemetry",
+    "telemetry.sdk.version": "1.44.0",
+    "service.instance.id": "e4f7234a-ab20-42db-8cbe-5ca1e4e089ea",
+    "service.name": "everos",
+    "service.version": "1.2.1"
+  },
+  "spans": [
+    {
+      "trace_id": "2ebeaa11b6ea2415724bd1a4013e89f3",
+      "span_id": "14b0698904aae406",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358414342796000,
+      "end_unix_nano": 1785358416284111000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-trip-booked",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "477698e868594a9c8b1dd33512ac1726"
+      }
+    },
+    {
+      "trace_id": "2ebeaa11b6ea2415724bd1a4013e89f3",
+      "span_id": "04c4716a319a2d2d",
+      "parent_span_id": "14b0698904aae406",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358414343242000,
+      "end_unix_nano": 1785358416283943000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1189,
+        "gen_ai.usage.output_tokens": 63
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "873705e809b70c71",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358416291840000,
+      "end_unix_nano": 1785358420080043000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-trip-booked",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "617604ced25541d9a04f235c6fb5741c"
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "5670849846c81576",
+      "parent_span_id": "873705e809b70c71",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358416291986000,
+      "end_unix_nano": 1785358417532533000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1189,
+        "gen_ai.usage.output_tokens": 69
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "21d934efce4cf557",
+      "parent_span_id": "873705e809b70c71",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358417542701000,
+      "end_unix_nano": 1785358420037010000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-trip-booked",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_7316ce945a52",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1264,
+        "gen_ai.usage.output_tokens": 112,
+        "langfuse.observation.output": "On May 20, 2026 at 8:54 PM UTC, Alice confirmed booking a week-long trip to Lisbon in October 2026, departing on October 12, 2026. The assistant acknowledged and recorded the plan immediately at 8:55 PM UTC. The conversation focused solely on finalizing the travel dates and destination without additional details or emotional expressions."
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "c9e991603d5a3838",
+      "parent_span_id": "873705e809b70c71",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358417558888000,
+      "end_unix_nano": 1785358431565601000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "2702eee4bac341a4909f8ba73ae70a28",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2062,
+        "gen_ai.usage.output_tokens": 491
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "2b53436b68316737",
+      "parent_span_id": "873705e809b70c71",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358417561407000,
+      "end_unix_nano": 1785358417561903000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "4b308173094448f8adc2351f90e6c38d",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "6c2481273a562340",
+      "parent_span_id": "873705e809b70c71",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358420040063000,
+      "end_unix_nano": 1785358420052297000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-trip-booked",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "f472fd847879da1b63c1f9e002d5c020",
+      "span_id": "35c96262f3e04889",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358420093186000,
+      "end_unix_nano": 1785358421343803000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-dentist",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "3d3bb2895bbd459d9d515651fdad9dc5"
+      }
+    },
+    {
+      "trace_id": "f472fd847879da1b63c1f9e002d5c020",
+      "span_id": "07a3c209fe38d0c1",
+      "parent_span_id": "35c96262f3e04889",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358420093369000,
+      "end_unix_nano": 1785358421343565000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1192,
+        "gen_ai.usage.output_tokens": 61
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "e35e786d1a8d8eed",
+      "parent_span_id": "873705e809b70c71",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358420094298000,
+      "end_unix_nano": 1785358421748776000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "4c301dd1211f41608c9232e91bf6cd5f",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1157,
+        "gen_ai.usage.output_tokens": 133
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "73432926ef5a7500",
+      "parent_span_id": "873705e809b70c71",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358420098476000,
+      "end_unix_nano": 1785358420357051000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "a587bb98253a4dec90956316e1a5cdd3",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "32426e2eabb9e0e7",
+      "parent_span_id": "73432926ef5a7500",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358420098562000,
+      "end_unix_nano": 1785358420345764000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 87
+      }
+    },
+    {
+      "trace_id": "adbd9e7c67ccd83dc37ab46f793ce085",
+      "span_id": "9d2241240de85170",
+      "parent_span_id": "73432926ef5a7500",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358420360879000,
+      "end_unix_nano": 1785358420384148000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "6ca69ba9c02f4def8425fb1e51fa8577",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated"
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "c23c3bd4941d3619",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358421358252000,
+      "end_unix_nano": 1785358425120278000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-dentist",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "da5932308250462e82d67dd017f5405d"
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "150f7e711095f07a",
+      "parent_span_id": "c23c3bd4941d3619",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358421358399000,
+      "end_unix_nano": 1785358423102938000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1192,
+        "gen_ai.usage.output_tokens": 61
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "7662df9818f1a8d2",
+      "parent_span_id": "c23c3bd4941d3619",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358423105817000,
+      "end_unix_nano": 1785358425100507000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-dentist",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_8bdef1af5f2c",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1267,
+        "gen_ai.usage.output_tokens": 112,
+        "langfuse.observation.output": "On May 27, 2026 at 8:54 PM UTC, Alice reported that the dentist had placed a crown on her lower left molar that day. She mentioned a follow-up dental check-up scheduled in six months. At 8:55 PM UTC, the assistant confirmed recording the crown placement on Alice's lower left molar and noted the check-up due in six months."
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "48608769e0e9901d",
+      "parent_span_id": "c23c3bd4941d3619",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358423119397000,
+      "end_unix_nano": 1785358423120397000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "c2215a77ca9a4fdb822ae117b7f8398a",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "df96a7fa795bde1e",
+      "parent_span_id": "c23c3bd4941d3619",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358423121620000,
+      "end_unix_nano": 1785358428824868000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "42dc939afa5c407dbd0807ded1f31dd4",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2065,
+        "gen_ai.usage.output_tokens": 521
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "dca9a49ab6a6a5b9",
+      "parent_span_id": "c23c3bd4941d3619",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358425101793000,
+      "end_unix_nano": 1785358425112927000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-dentist",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "376c650e7d4f1bb361b642a0faa47b7d",
+      "span_id": "279efa890970bae2",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358425133198000,
+      "end_unix_nano": 1785358427502401000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-trip-changed",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "38aa5c4655714dbe912d34165d5eab10"
+      }
+    },
+    {
+      "trace_id": "376c650e7d4f1bb361b642a0faa47b7d",
+      "span_id": "dcc37271bd6791a6",
+      "parent_span_id": "279efa890970bae2",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358425133317000,
+      "end_unix_nano": 1785358427502262000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1189,
+        "gen_ai.usage.output_tokens": 67
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "9296509a99b29754",
+      "parent_span_id": "c23c3bd4941d3619",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358425134494000,
+      "end_unix_nano": 1785358427230420000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "5f6250c992bb430aac26c0a10c089266",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1160,
+        "gen_ai.usage.output_tokens": 138
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "681e5fcf5aa8c4fc",
+      "parent_span_id": "c23c3bd4941d3619",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358425137842000,
+      "end_unix_nano": 1785358425335727000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "7ee1074038cb46f79f541b918869c3c2",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "69727b5e1de1fdf9",
+      "parent_span_id": "681e5fcf5aa8c4fc",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358425137910000,
+      "end_unix_nano": 1785358425327259000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 85
+      }
+    },
+    {
+      "trace_id": "c479852553a9942abb7f150cd786cf32",
+      "span_id": "848b563d0dfd6d4a",
+      "parent_span_id": "681e5fcf5aa8c4fc",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358425360312000,
+      "end_unix_nano": 1785358427975531000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "6e2037bf9e104e19b9919632af2ab550",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 533,
+        "gen_ai.usage.output_tokens": 161
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "b0cbe8f0eb825937",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358427510365000,
+      "end_unix_nano": 1785358430459321000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-trip-changed",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "10c8fc567b2c4d46869fa4364b3012bd"
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "308014c09cf44fb1",
+      "parent_span_id": "b0cbe8f0eb825937",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358427510555000,
+      "end_unix_nano": 1785358428897638000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1189,
+        "gen_ai.usage.output_tokens": 67
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "1dd70b98449c6940",
+      "parent_span_id": "b0cbe8f0eb825937",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358428903236000,
+      "end_unix_nano": 1785358430443995000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-trip-changed",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_f252bba4c38b",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1264,
+        "gen_ai.usage.output_tokens": 104,
+        "langfuse.observation.output": "On May 25, 2026 at 8:54 PM UTC, Alice informed that the planned October 2026 trip was changed from Lisbon to Porto because her sister moved the wedding to Porto. The assistant confirmed the update at 8:55 PM UTC, noting the October trip destination was now Porto instead of Lisbon due to the wedding relocation."
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "14c15448e6cd0db3",
+      "parent_span_id": "b0cbe8f0eb825937",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358428916175000,
+      "end_unix_nano": 1785358433214395000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "16ef2dd06b6b405ca2e26841e56dbd31",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2062,
+        "gen_ai.usage.output_tokens": 494
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "110d04ba4a41aa3a",
+      "parent_span_id": "b0cbe8f0eb825937",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358428923038000,
+      "end_unix_nano": 1785358428923390000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "7fb8a54ef0b748ee916131dc54881a36",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "5c4033e55e9594e4",
+      "parent_span_id": "b0cbe8f0eb825937",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358430444445000,
+      "end_unix_nano": 1785358430449706000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-trip-changed",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "6125a693741762557aeb7012f926ed9c",
+      "span_id": "76ce7f5dd72128f3",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358430471372000,
+      "end_unix_nano": 1785358431542340000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "974e33f6ab20481796138f619fdf58f5"
+      }
+    },
+    {
+      "trace_id": "6125a693741762557aeb7012f926ed9c",
+      "span_id": "f636f835c62664c1",
+      "parent_span_id": "76ce7f5dd72128f3",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358430471517000,
+      "end_unix_nano": 1785358431542139000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1185,
+        "gen_ai.usage.output_tokens": 49
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "cd675fef7bc35c68",
+      "parent_span_id": "b0cbe8f0eb825937",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358430474769000,
+      "end_unix_nano": 1785358432409035000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "19d784dd1b7e4dc5a2134b43a8beb040",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1152,
+        "gen_ai.usage.output_tokens": 117
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "a2899039ea26c2c3",
+      "parent_span_id": "b0cbe8f0eb825937",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358430480588000,
+      "end_unix_nano": 1785358431783226000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "456e1b8e27fc4249a4ec84bdbbe1aea0",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "6120d0c593966ec7",
+      "parent_span_id": "a2899039ea26c2c3",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358430480638000,
+      "end_unix_nano": 1785358431760822000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 79
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "d1b72930d92b285b",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358431549206000,
+      "end_unix_nano": 1785358434429423000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "11345b298ed94342a093b89e25f8bbbd"
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "f16219e5bebe53e8",
+      "parent_span_id": "d1b72930d92b285b",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358431549328000,
+      "end_unix_nano": 1785358432739531000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1185,
+        "gen_ai.usage.output_tokens": 60
+      }
+    },
+    {
+      "trace_id": "5214899805c7b89725b1a659c738791b",
+      "span_id": "bf70e421445ce8d2",
+      "parent_span_id": "a2899039ea26c2c3",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358431797839000,
+      "end_unix_nano": 1785358434399679000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "3c698537be0e4333b59bdc000b435dcd",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1223,
+        "gen_ai.usage.output_tokens": 215
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "da7c175e38e328d7",
+      "parent_span_id": "d1b72930d92b285b",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358432743354000,
+      "end_unix_nano": 1785358434385883000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_77b409d4bbff",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1260,
+        "gen_ai.usage.output_tokens": 84,
+        "langfuse.observation.output": "On June 10, 2026 at 8:54 PM UTC, Alice shared that she started cello lessons with her teacher Marta, scheduled every Thursday at 19:00. The assistant acknowledged and recorded this recurring weekly activity."
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "79e48cf32cc3e74b",
+      "parent_span_id": "d1b72930d92b285b",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358432759916000,
+      "end_unix_nano": 1785358439810126000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "cf52020a20eb45f3a5b0b6ffb8a8efa8",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2058,
+        "gen_ai.usage.output_tokens": 472
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "92690434ee687bd9",
+      "parent_span_id": "d1b72930d92b285b",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358432763017000,
+      "end_unix_nano": 1785358432763322000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "7db1816e4ca34b68a26ea8acb279edbf",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "a1629282ddb133c9",
+      "parent_span_id": "d1b72930d92b285b",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358434386568000,
+      "end_unix_nano": 1785358434400298000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "9c54229035c8c43b0af022ec9d39bcc9",
+      "span_id": "1a9ef216830113f4",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358434448926000,
+      "end_unix_nano": 1785358436017549000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-cat-allergy",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "2f98630d061b4f0ca576f21c1980991f"
+      }
+    },
+    {
+      "trace_id": "9c54229035c8c43b0af022ec9d39bcc9",
+      "span_id": "6b0dd55767259969",
+      "parent_span_id": "1a9ef216830113f4",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358434449133000,
+      "end_unix_nano": 1785358436017418000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1196,
+        "gen_ai.usage.output_tokens": 67
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "9f16ad2dccd73255",
+      "parent_span_id": "d1b72930d92b285b",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358434454002000,
+      "end_unix_nano": 1785358435879599000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "2dce1385a933483b98485b258b2798a5",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "a8710228e7967562",
+      "parent_span_id": "9f16ad2dccd73255",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358434454065000,
+      "end_unix_nano": 1785358435852850000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 56
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "db9d975e6bdea15d",
+      "parent_span_id": "d1b72930d92b285b",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358434458193000,
+      "end_unix_nano": 1785358435997934000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "5b7467116a4547c9868af76f12e44495",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1128,
+        "gen_ai.usage.output_tokens": 109
+      }
+    },
+    {
+      "trace_id": "7aa27a19ec765a417720123614ab4e0e",
+      "span_id": "7c45d17a070aa30b",
+      "parent_span_id": "9f16ad2dccd73255",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358435884981000,
+      "end_unix_nano": 1785358435896990000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "197e4f12f8b7432bb13639ffb8875582",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated"
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "4a54b5de7bcddcc4",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358436029262000,
+      "end_unix_nano": 1785358438923375000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-cat-allergy",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "b6d13376ace148ccb47744440468c9e0"
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "41782d00f3c651c1",
+      "parent_span_id": "4a54b5de7bcddcc4",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358436029355000,
+      "end_unix_nano": 1785358437448687000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1196,
+        "gen_ai.usage.output_tokens": 67
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "5ac81b2d5f3c9fef",
+      "parent_span_id": "4a54b5de7bcddcc4",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358437452646000,
+      "end_unix_nano": 1785358438898308000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-cat-allergy",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_5695535f303e",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1271,
+        "gen_ai.usage.output_tokens": 104,
+        "langfuse.observation.output": "On June 17, 2026 at 8:54 PM UTC, Alice reported that the veterinarian diagnosed Mochi with a chicken allergy and that they switched Mochi's food to salmon-based. At 8:55 PM UTC, the assistant acknowledged Mochi's chicken allergy and confirmed that chicken would be excluded from any future food suggestions for Mochi."
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "349e6d6effe597ab",
+      "parent_span_id": "4a54b5de7bcddcc4",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358437477463000,
+      "end_unix_nano": 1785358445854881000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "0f706206c02c48dc948bed8dfcea07dd",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2069,
+        "gen_ai.usage.output_tokens": 481
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "7936c16510613834",
+      "parent_span_id": "4a54b5de7bcddcc4",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358437480341000,
+      "end_unix_nano": 1785358437480692000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "7aa6089cd840428aa860fc1595c63404",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "a9ec2f99f93ded64",
+      "parent_span_id": "4a54b5de7bcddcc4",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358438898937000,
+      "end_unix_nano": 1785358438909095000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-cat-allergy",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "532b9e4986e2213fd9c757d5a69a6a55",
+      "span_id": "6f231b1f4115c27e",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358438934231000,
+      "end_unix_nano": 1785358439944677000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-bike",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "e4098b63d19846ca9b671c0289532fd0"
+      }
+    },
+    {
+      "trace_id": "532b9e4986e2213fd9c757d5a69a6a55",
+      "span_id": "a4ff438a5a9d2901",
+      "parent_span_id": "6f231b1f4115c27e",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358438934456000,
+      "end_unix_nano": 1785358439944587000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1199,
+        "gen_ai.usage.output_tokens": 50
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "a4414da166159835",
+      "parent_span_id": "4a54b5de7bcddcc4",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358438940393000,
+      "end_unix_nano": 1785358440054262000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "464f718626184df8a25d18491b39bfe8",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "b1a43731b2c7c60b",
+      "parent_span_id": "a4414da166159835",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358438940959000,
+      "end_unix_nano": 1785358440034902000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 82
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "b2919b0c83021008",
+      "parent_span_id": "4a54b5de7bcddcc4",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358438948176000,
+      "end_unix_nano": 1785358441205135000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "7ca8dac0d1914fa9af6fe0f3f2195f02",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1153,
+        "gen_ai.usage.output_tokens": 162
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "f182b157ceb18fcd",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358439948416000,
+      "end_unix_nano": 1785358444070584000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-bike",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "57120b877c4247718726daad8fd2e923"
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "5ff7e9837d930dac",
+      "parent_span_id": "f182b157ceb18fcd",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358439948582000,
+      "end_unix_nano": 1785358441138664000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1199,
+        "gen_ai.usage.output_tokens": 50
+      }
+    },
+    {
+      "trace_id": "b6f9f8217ff2ffccecc922d96fa3c73e",
+      "span_id": "7c84d525db611cc3",
+      "parent_span_id": "a4414da166159835",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358440059831000,
+      "end_unix_nano": 1785358440068987000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "e99c91db89194599a5d215f0e0668d46",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated"
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "7b7d70165845b050",
+      "parent_span_id": "f182b157ceb18fcd",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358441141663000,
+      "end_unix_nano": 1785358444036192000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-bike",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_fa3f18f6cd86",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1274,
+        "gen_ai.usage.output_tokens": 113,
+        "langfuse.observation.output": "On June 24, 2026 at 8:54 PM UTC, Alice reported that Radhaus replaced the rear derailleur on her bike and was advised to swap the chain at 3000 km. One minute later, at 8:55 PM UTC, the assistant confirmed the installation of the new rear derailleur from Radhaus and reiterated the chain replacement recommendation at 3000 km."
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "aae8aa92e068aaf9",
+      "parent_span_id": "f182b157ceb18fcd",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358441160872000,
+      "end_unix_nano": 1785358445352524000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "31da1ae81e9046eb98f44ddb9ce8921c",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2072,
+        "gen_ai.usage.output_tokens": 404
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "96638b4dfc3a246b",
+      "parent_span_id": "f182b157ceb18fcd",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358441164731000,
+      "end_unix_nano": 1785358441165073000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "1c09d8575b454ad4ae201bb4d544d654",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "9fe5513e9eb69cab",
+      "parent_span_id": "f182b157ceb18fcd",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358444037505000,
+      "end_unix_nano": 1785358444046939000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-bike",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "23a615fb0218a80e399f77f928f9a862",
+      "span_id": "02860f364f0c0a31",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358444079475000,
+      "end_unix_nano": 1785358445358401000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-sourdough",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "c7638ab802224d20b0c58cf1c630f01c"
+      }
+    },
+    {
+      "trace_id": "23a615fb0218a80e399f77f928f9a862",
+      "span_id": "96b1088d9dcdda93",
+      "parent_span_id": "02860f364f0c0a31",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358444079637000,
+      "end_unix_nano": 1785358445358289000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1316,
+        "gen_ai.usage.output_tokens": 52
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "db2903011605d5d6",
+      "parent_span_id": "f182b157ceb18fcd",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358444083711000,
+      "end_unix_nano": 1785358444355887000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "50174f4ce17c4e34a5ac67e9a17acfd6",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "161ca946978af263",
+      "parent_span_id": "db2903011605d5d6",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358444083766000,
+      "end_unix_nano": 1785358444332424000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 90
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "cfec98e4323abb50",
+      "parent_span_id": "f182b157ceb18fcd",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358444086174000,
+      "end_unix_nano": 1785358446282720000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "64dcab8573274f1fac2909fac4d3eaa9",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1161,
+        "gen_ai.usage.output_tokens": 135
+      }
+    },
+    {
+      "trace_id": "d97ff1f3600b670fa9fb7b39704e97d8",
+      "span_id": "727aac588e48fa37",
+      "parent_span_id": "db2903011605d5d6",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358444360082000,
+      "end_unix_nano": 1785358444379393000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "96f7442c16964900a82084265120d8fe",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated"
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "378e2eb77a7e4a2d",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358445368883000,
+      "end_unix_nano": 1785358451232634000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-sourdough",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "3d3fe1b5de6c4775a30ec900914e99d3"
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "a4062bab75c8b2a9",
+      "parent_span_id": "378e2eb77a7e4a2d",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358445369336000,
+      "end_unix_nano": 1785358447537600000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1316,
+        "gen_ai.usage.output_tokens": 52
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "a51db5916c38d983",
+      "parent_span_id": "378e2eb77a7e4a2d",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358447541805000,
+      "end_unix_nano": 1785358451102885000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-sourdough",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_b93fd49637f1",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1425,
+        "gen_ai.usage.output_tokens": 229,
+        "langfuse.observation.output": "On July 1, 2026, at 8:54 PM UTC, Alice reported that her sourdough bread had come out flat for three consecutive bakes despite her starter doubling by noon, indicating the starter was not the issue. At 8:55 PM UTC, the assistant explained that the kitchen temperature dropped to about 16°C overnight, and since the dough was left on the counter until morning, the bulk proofing stalled because it requires 24 to 26°C, causing the loaf to spread instead of holding its shape. At 8:56 PM UTC, Alice shared that proofing the dough in the oven with just the light on, which maintains about 24°C, resulted in the best crumb she had achieved. At 8:57 PM UTC, the assistant confirmed that the oven light's temperature fixed the problem and advised judging proofing by the dough's condition rather than the clock, as the same recipe requires different proofing times at varying temperatures."
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "36070aa9d0f3a5c1",
+      "parent_span_id": "378e2eb77a7e4a2d",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358447557700000,
+      "end_unix_nano": 1785358453541771000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "6cabe9f2ec59428798cd3f545ab3f4f5",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2183,
+        "gen_ai.usage.output_tokens": 504
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "3669cc13d6a58f51",
+      "parent_span_id": "378e2eb77a7e4a2d",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358447560473000,
+      "end_unix_nano": 1785358447560816000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "a4256f275d1e462b904e2084eedbbe4d",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "16c7e488324de54d",
+      "parent_span_id": "378e2eb77a7e4a2d",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358451110309000,
+      "end_unix_nano": 1785358451138874000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-sourdough",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "598918dec14611069b05b058918df57f",
+      "span_id": "368cfc4ac85cf8cd",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358451531433000,
+      "end_unix_nano": 1785358453184463000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "163d6bd4d63f46a6829f7e18ef348333"
+      }
+    },
+    {
+      "trace_id": "598918dec14611069b05b058918df57f",
+      "span_id": "74d4730c0d2228cd",
+      "parent_span_id": "368cfc4ac85cf8cd",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358451534832000,
+      "end_unix_nano": 1785358453184172000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1187,
+        "gen_ai.usage.output_tokens": 49
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "2708927fda45f7c3",
+      "parent_span_id": "378e2eb77a7e4a2d",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358451684373000,
+      "end_unix_nano": 1785358453571918000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "9324a23323f64684b804d28d0aadeda3",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "fda31c6466839236",
+      "parent_span_id": "2708927fda45f7c3",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358451685706000,
+      "end_unix_nano": 1785358453565555000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 210
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "833752e480ef80c5",
+      "parent_span_id": "378e2eb77a7e4a2d",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358451945882000,
+      "end_unix_nano": 1785358458475442000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "56dbe406c780488d8eac8166bc45bbad",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1279,
+        "gen_ai.usage.output_tokens": 245
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "82bfa8bf3d834904",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358453218016000,
+      "end_unix_nano": 1785358456122089000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "19eb8381ca424795874bb477b4b236c7"
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "6b9696fa5abf7fc3",
+      "parent_span_id": "82bfa8bf3d834904",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358453218891000,
+      "end_unix_nano": 1785358454286146000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1187,
+        "gen_ai.usage.output_tokens": 51
+      }
+    },
+    {
+      "trace_id": "541a26713c44555b64f1a324429261a4",
+      "span_id": "c75705292f744271",
+      "parent_span_id": "2708927fda45f7c3",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358453577807000,
+      "end_unix_nano": 1785358453610151000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "2f0b9c16dd774b2189b8d2037d2b729a",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated"
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "35025d3c7b51f311",
+      "parent_span_id": "82bfa8bf3d834904",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358454289781000,
+      "end_unix_nano": 1785358456098905000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_848276eef358",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1262,
+        "gen_ai.usage.output_tokens": 105,
+        "langfuse.observation.output": "On July 8, 2026 at 8:54 PM UTC, Alice informed that Tomas, the neighbor next door, currently holds their spare keys and waters their plants when they travel. The assistant confirmed this arrangement at 8:55 PM UTC, restating that Tomas manages the spare keys and plant watering duties during their absences."
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "397e646d9c249a40",
+      "parent_span_id": "82bfa8bf3d834904",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358454303614000,
+      "end_unix_nano": 1785358454304691000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "c588b91638a54ffb8bbc6026896df6ce",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "95964a22e2b53386",
+      "parent_span_id": "82bfa8bf3d834904",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358454306315000,
+      "end_unix_nano": 1785358470212379000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "42f6f517a5fe44e1a1b1b5540095d798",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2060,
+        "gen_ai.usage.output_tokens": 476
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "47ed815ab43b3ed1",
+      "parent_span_id": "82bfa8bf3d834904",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358456099738000,
+      "end_unix_nano": 1785358456107516000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "3cddef664831cb3072022f6aa0e9d576",
+      "span_id": "0b3b771be2c851a8",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358456130941000,
+      "end_unix_nano": 1785358457245675000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-physio",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "28fb81c0cb3943b2a1bea0b19c746b3a"
+      }
+    },
+    {
+      "trace_id": "3cddef664831cb3072022f6aa0e9d576",
+      "span_id": "be1551bc25b0f1a1",
+      "parent_span_id": "0b3b771be2c851a8",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358456131448000,
+      "end_unix_nano": 1785358457245548000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1201,
+        "gen_ai.usage.output_tokens": 58
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "dd8192093b179c45",
+      "parent_span_id": "82bfa8bf3d834904",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358456131893000,
+      "end_unix_nano": 1785358582590023000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "760dc98611a84811bdbe13f086a55717",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "2005eb0231f96f44",
+      "parent_span_id": "dd8192093b179c45",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358456131942000,
+      "end_unix_nano": 1785358582543727000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 74
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "4ddfa96917befee5",
+      "parent_span_id": "82bfa8bf3d834904",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358456136564000,
+      "end_unix_nano": 1785358457606424000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "edcf6769dc444d10aaeab6086b5ea62c",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1150,
+        "gen_ai.usage.output_tokens": 108
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "48b60c872a4fe990",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358457249102000,
+      "end_unix_nano": 1785358460195242000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-physio",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "01d70859555f4e5cbd30cf4520c5920a"
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "0143e3b5fa38228c",
+      "parent_span_id": "48b60c872a4fe990",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358457249266000,
+      "end_unix_nano": 1785358458459582000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1201,
+        "gen_ai.usage.output_tokens": 62
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "87e37940f1d774ce",
+      "parent_span_id": "48b60c872a4fe990",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358458465214000,
+      "end_unix_nano": 1785358460148708000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-physio",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_e54ddf9274aa",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1276,
+        "gen_ai.usage.output_tokens": 118,
+        "langfuse.observation.output": "On July 15, 2026 at 8:54 PM UTC, Alice reported starting physiotherapy for her right shoulder, involving band exercises twice daily and a restriction on overhead presses until medically cleared. At 8:55 PM UTC, the assistant confirmed the physiotherapy plan, emphasizing the twice-daily band exercises and the prohibition of overhead presses until clearance. The conversation focused on managing Alice's shoulder recovery with specific exercise guidelines."
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "0c3d5f122d398da2",
+      "parent_span_id": "48b60c872a4fe990",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358458479113000,
+      "end_unix_nano": 1785358463178276000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "a2a0b80d72484123a1024f7ac14dcd7a",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2074,
+        "gen_ai.usage.output_tokens": 460
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "70b0194289cd46dc",
+      "parent_span_id": "48b60c872a4fe990",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358458483573000,
+      "end_unix_nano": 1785358458483765000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "a7367322bd2d4498be328c7cc443c812",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "42640d03efb42d53",
+      "parent_span_id": "48b60c872a4fe990",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358460154207000,
+      "end_unix_nano": 1785358460169731000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-physio",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "6a1c4517ec351b98",
+      "parent_span_id": "48b60c872a4fe990",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358460206072000,
+      "end_unix_nano": 1785358597894033000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "789940b540744cd0b385ca63bf189f1f",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "03beb53efcae941c4a5066afad508f71",
+      "span_id": "aeabd098ea5a82f8",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358460208040000,
+      "end_unix_nano": 1785358462349914000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-food-rules",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "2a6c17cd671b44028683b72cadec4c4a"
+      }
+    },
+    {
+      "trace_id": "03beb53efcae941c4a5066afad508f71",
+      "span_id": "90bfe5f19b7db953",
+      "parent_span_id": "aeabd098ea5a82f8",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358460208191000,
+      "end_unix_nano": 1785358462349609000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1194,
+        "gen_ai.usage.output_tokens": 49
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "97268be254cad540",
+      "parent_span_id": "48b60c872a4fe990",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358460209046000,
+      "end_unix_nano": 1785358462467365000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "3a70d00771184c60991f29f8afe45a53",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1168,
+        "gen_ai.usage.output_tokens": 174
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "39a6270d0e0ca226",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358462361961000,
+      "end_unix_nano": 1785358465659323000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-food-rules",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "1fc02076e07d45a8b3027d5d62cfe66b"
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "87f5dd3e8ddf7c33",
+      "parent_span_id": "39a6270d0e0ca226",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358462362228000,
+      "end_unix_nano": 1785358463820660000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1194,
+        "gen_ai.usage.output_tokens": 63
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "ca3350f377194da3",
+      "parent_span_id": "39a6270d0e0ca226",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358463825327000,
+      "end_unix_nano": 1785358465636381000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-food-rules",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_963c95a52865",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1269,
+        "gen_ai.usage.output_tokens": 97,
+        "langfuse.observation.output": "On July 21, 2026 at 8:54 PM UTC, Alice communicated her dietary restrictions for meal planning, specifying that she is vegetarian and cannot tolerate mushrooms or fish. At 8:55 PM UTC, the assistant acknowledged and recorded these food rules to ensure future meal plans exclude fish and mushrooms, respecting Alice's vegetarian preference."
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "0241fdb9f89db8f7",
+      "parent_span_id": "39a6270d0e0ca226",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358463844464000,
+      "end_unix_nano": 1785358468468237000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "6249ba70f0854f7cbaccf7d2882d80eb",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2067,
+        "gen_ai.usage.output_tokens": 535
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "b0ce44c9d8aafc54",
+      "parent_span_id": "39a6270d0e0ca226",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358463850186000,
+      "end_unix_nano": 1785358463850548000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "eca0fd81d8bd4ef59d52b88ed9f7165c",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "80151d99a0cd3380",
+      "parent_span_id": "39a6270d0e0ca226",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358465638267000,
+      "end_unix_nano": 1785358465647569000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-food-rules",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "f80506ddebe096ecbb55d965ebe29bae",
+      "span_id": "3281132bf6ca0283",
+      "parent_span_id": null,
+      "name": "everos.memory.add",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358465673158000,
+      "end_unix_nano": 1785358466887416000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-morning-routine",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": false,
+        "langfuse.trace.metadata.request_id": "8efbd01d814546f59926742f413ab435"
+      }
+    },
+    {
+      "trace_id": "f80506ddebe096ecbb55d965ebe29bae",
+      "span_id": "73cd36c7e14813a2",
+      "parent_span_id": "3281132bf6ca0283",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358465673372000,
+      "end_unix_nano": 1785358466887373000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1188,
+        "gen_ai.usage.output_tokens": 64
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "21a17a5277d6bdad",
+      "parent_span_id": "39a6270d0e0ca226",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358465676094000,
+      "end_unix_nano": 1785358467821200000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "bc26e0519c324e85b54a4ad28fccda91",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1150,
+        "gen_ai.usage.output_tokens": 153
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "9f0d650574fe2864",
+      "parent_span_id": "39a6270d0e0ca226",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358465682206000,
+      "end_unix_nano": 1785358712247440000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "32c2f1ca464049529bb1b73e1feb3fe8",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "58bf1fb0c87234f5",
+      "parent_span_id": null,
+      "name": "everos.memory.flush",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358466889353000,
+      "end_unix_nano": 1785358471014896000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-morning-routine",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.mode": "agent",
+        "langfuse.trace.metadata.is_final": true,
+        "langfuse.trace.metadata.request_id": "d03abbce96314ba49e892868b41d3564"
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "15fc8b80915717d8",
+      "parent_span_id": "58bf1fb0c87234f5",
+      "name": "everos.memcell.boundary",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358466889447000,
+      "end_unix_nano": 1785358468161588000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1188,
+        "gen_ai.usage.output_tokens": 58
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "3d7782988b709c5e",
+      "parent_span_id": "58bf1fb0c87234f5",
+      "name": "everos.extract",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358468167663000,
+      "end_unix_nano": 1785358470959218000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.session.id": "everos-demo-morning-routine",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.memcell_id": "mc_20aaa81afdf4",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1263,
+        "gen_ai.usage.output_tokens": 102,
+        "langfuse.observation.output": "On July 24, 2026 at 8:54 PM UTC, Alice shared that she runs before work every morning, which causes her breakfast to be delayed, usually around 10 AM. At 8:55 PM UTC, the assistant acknowledged and recorded that Alice runs each morning before work and typically eats breakfast late, around 10 AM."
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "5496360c5f0ab7ad",
+      "parent_span_id": "58bf1fb0c87234f5",
+      "name": "everos.ome.extract_foresight",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358468180568000,
+      "end_unix_nano": 1785358472650323000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_foresight",
+        "langfuse.trace.metadata.run_id": "2b853a356e3b43c88b1f9f8a9179219a",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:UserPipelineStarted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2061,
+        "gen_ai.usage.output_tokens": 457
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "8ab9bc67d7d0f615",
+      "parent_span_id": "58bf1fb0c87234f5",
+      "name": "everos.ome.extract_agent_case",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358468185364000,
+      "end_unix_nano": 1785358468185603000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_agent_case",
+        "langfuse.trace.metadata.run_id": "1826bffd722a4580aca730be941b6195",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:AgentPipelineStarted"
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "5f5a77b987c307e1",
+      "parent_span_id": "58bf1fb0c87234f5",
+      "name": "everos.persist.markdown",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358470959770000,
+      "end_unix_nano": 1785358470996379000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.session.id": "everos-demo-morning-routine",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.observation.output": "default_app/default_project/users/alice/episodes/episode-2026-07-29.md"
+      }
+    },
+    {
+      "trace_id": "8c056ed34b024e13ec4e142481713ff2",
+      "span_id": "01b216e967be53c6",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471059927000,
+      "end_unix_nano": 1785358471134223000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-trip-booked",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "02b2254bf80c4a518bb276ec70fb789c",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"We booked the October trip: Lisbon, a week, flying out on the 12th.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000001\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 4.411255836486816
+      }
+    },
+    {
+      "trace_id": "8c056ed34b024e13ec4e142481713ff2",
+      "span_id": "b654a6fca2c8f755",
+      "parent_span_id": "01b216e967be53c6",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471060392000,
+      "end_unix_nano": 1785358471133730000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "76f76d8151a868f1",
+      "parent_span_id": "58bf1fb0c87234f5",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471068154000,
+      "end_unix_nano": 1785358473320444000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "37570418171c4066bc795f43c32508e7",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1152,
+        "gen_ai.usage.output_tokens": 113
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "67d0e61beb031d20",
+      "parent_span_id": "58bf1fb0c87234f5",
+      "name": "everos.ome.trigger_profile_clustering",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471074388000,
+      "end_unix_nano": 1785358712372635000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "trigger_profile_clustering",
+        "langfuse.trace.metadata.run_id": "82bbbb69d50b4b07a5b2130f513d333c",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted"
+      }
+    },
+    {
+      "trace_id": "0d73edb2500d161b409b2b4b0413d3cd",
+      "span_id": "016d76149697b019",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471137367000,
+      "end_unix_nano": 1785358471150995000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-dentist",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "342be5255cf2410dbb93ff605c128f55",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"The dentist put a crown on my lower left molar today. Check-up in six months.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000002\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 12.67291259765625
+      }
+    },
+    {
+      "trace_id": "0d73edb2500d161b409b2b4b0413d3cd",
+      "span_id": "e45142298f590012",
+      "parent_span_id": "016d76149697b019",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471137475000,
+      "end_unix_nano": 1785358471150818000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "a6d4152018e5fd9a6308f1ed48353b62",
+      "span_id": "14f882904ebe3f3f",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471153793000,
+      "end_unix_nano": 1785358471166829000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-trip-changed",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "627b6bf2c15643199e399f2d9d1e2953",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"October changed. We cancelled Lisbon and booked Porto instead, my sister moved the wedding there.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000003\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 9.385517120361328
+      }
+    },
+    {
+      "trace_id": "a6d4152018e5fd9a6308f1ed48353b62",
+      "span_id": "1910f49eeb47bb0b",
+      "parent_span_id": "14f882904ebe3f3f",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471153920000,
+      "end_unix_nano": 1785358471166641000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "fe8ae362e0f5bdac1f2f2036a9edadc2",
+      "span_id": "1e2e413c59723a9c",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471169060000,
+      "end_unix_nano": 1785358471172212000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "50351ab20cb44c9b8837a2faf8e37fc2",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I started cello lessons. My teacher is Marta, Thursdays at 19:00.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "fe8ae362e0f5bdac1f2f2036a9edadc2",
+      "span_id": "8215bfa2c45a78d7",
+      "parent_span_id": "1e2e413c59723a9c",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358471169163000,
+      "end_unix_nano": 1785358471172120000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "7166ed13c36d4536302f37ed0ee730cd",
+      "span_id": "ed10ba7927540226",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358481185300000,
+      "end_unix_nano": 1785358481199866000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "7697e3043f9b43d1b50aae29fe939367",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I started cello lessons. My teacher is Marta, Thursdays at 19:00.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "7166ed13c36d4536302f37ed0ee730cd",
+      "span_id": "cc8542bfb366a337",
+      "parent_span_id": "ed10ba7927540226",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358481186034000,
+      "end_unix_nano": 1785358481198014000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "1a645b0c87775b42d37c8dd60e1992ed",
+      "span_id": "563dc1846bab826b",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358491236854000,
+      "end_unix_nano": 1785358491258824000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "3c61332312314bd28c52f98b606c4992",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I started cello lessons. My teacher is Marta, Thursdays at 19:00.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "1a645b0c87775b42d37c8dd60e1992ed",
+      "span_id": "a321d8c1370180a6",
+      "parent_span_id": "563dc1846bab826b",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358491239371000,
+      "end_unix_nano": 1785358491257989000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "9df82a09a4c7c556edf0ee4d1c4519e9",
+      "span_id": "34e4ea99af0230cd",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358501275400000,
+      "end_unix_nano": 1785358501288956000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "367ae05ee87544a78b05b41612ec2d14",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I started cello lessons. My teacher is Marta, Thursdays at 19:00.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "9df82a09a4c7c556edf0ee4d1c4519e9",
+      "span_id": "5979f21254530b55",
+      "parent_span_id": "34e4ea99af0230cd",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358501275911000,
+      "end_unix_nano": 1785358501288697000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "a6a1442729ec29f7f6be1a45e262f570",
+      "span_id": "5438826c331308b7",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358511298780000,
+      "end_unix_nano": 1785358511311426000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "7aca53d491c34098af654416894a859e",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I started cello lessons. My teacher is Marta, Thursdays at 19:00.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "a6a1442729ec29f7f6be1a45e262f570",
+      "span_id": "dda22d07e38a4392",
+      "parent_span_id": "5438826c331308b7",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358511299157000,
+      "end_unix_nano": 1785358511310552000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "6664d5ba28e808b6a446f4dc25b7f822",
+      "span_id": "e2e1291064b8f373",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358521339183000,
+      "end_unix_nano": 1785358521348235000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "2681a025e23a41afa63439a65a39122a",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I started cello lessons. My teacher is Marta, Thursdays at 19:00.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "6664d5ba28e808b6a446f4dc25b7f822",
+      "span_id": "53dd008a6d671fab",
+      "parent_span_id": "e2e1291064b8f373",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358521339560000,
+      "end_unix_nano": 1785358521347925000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "0ce5c0301ad24c447f0c40686220a041",
+      "span_id": "14927c43b90bd7c1",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531379463000,
+      "end_unix_nano": 1785358531407308000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cello",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "38bcaa862b1b42eab0a03df1993f2067",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I started cello lessons. My teacher is Marta, Thursdays at 19:00.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000004\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 19.582921981811523
+      }
+    },
+    {
+      "trace_id": "0ce5c0301ad24c447f0c40686220a041",
+      "span_id": "20af9d1a120e06a2",
+      "parent_span_id": "14927c43b90bd7c1",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531380683000,
+      "end_unix_nano": 1785358531406901000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "577adae6fb09ef08eaa0ae275627bb39",
+      "span_id": "d9451a3aef10f6a1",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531413178000,
+      "end_unix_nano": 1785358531420931000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-cat-allergy",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "4f969d738a66401ab396d6107b378754",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"The vet says Mochi is allergic to chicken. We switched her to the salmon food.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000005\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 12.041586875915527
+      }
+    },
+    {
+      "trace_id": "577adae6fb09ef08eaa0ae275627bb39",
+      "span_id": "f9ccfd5f4f7d6c86",
+      "parent_span_id": "d9451a3aef10f6a1",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531413307000,
+      "end_unix_nano": 1785358531420775000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "43104f341cb3c639acbf352528a29cfe",
+      "span_id": "b20b0c7d3517c1db",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531423057000,
+      "end_unix_nano": 1785358531430996000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-bike",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "ab935617892e49fb8a86fae3e224a24a",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Radhaus replaced the rear derailleur on my bike. They said to swap the chain at 3000 km.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000006\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 21.879318237304688
+      }
+    },
+    {
+      "trace_id": "43104f341cb3c639acbf352528a29cfe",
+      "span_id": "4b85b181ecbd2f65",
+      "parent_span_id": "b20b0c7d3517c1db",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531423168000,
+      "end_unix_nano": 1785358531430856000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "4eb34481c50530bfc3e6ddc8dc7270cb",
+      "span_id": "75fe7828cab42bd0",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531432798000,
+      "end_unix_nano": 1785358531437841000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-sourdough",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "700fea8ffda4477aa071479d53a64fd2",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"My sourdough came out flat three bakes running. The starter doubles by noon, so that is not it.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000007\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 12.897354125976562
+      }
+    },
+    {
+      "trace_id": "4eb34481c50530bfc3e6ddc8dc7270cb",
+      "span_id": "01cb6f3c5372c844",
+      "parent_span_id": "75fe7828cab42bd0",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531432895000,
+      "end_unix_nano": 1785358531437719000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "5e168140f86eb60d00f98e60ee262ce8",
+      "span_id": "bda45e8ec93277c9",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531439483000,
+      "end_unix_nano": 1785358531442598000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "c40682c6e1344aea903a000b7801fb93",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "5e168140f86eb60d00f98e60ee262ce8",
+      "span_id": "711194e20b41b43d",
+      "parent_span_id": "bda45e8ec93277c9",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358531439570000,
+      "end_unix_nano": 1785358531442514000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "add49272f8b39b6af98cd2fdc0e77203",
+      "span_id": "175b7b618206caf2",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358541458051000,
+      "end_unix_nano": 1785358541471487000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "82adadd08cf74031ad48e858b798fd0d",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "add49272f8b39b6af98cd2fdc0e77203",
+      "span_id": "9c71c6c0eee3fcb4",
+      "parent_span_id": "175b7b618206caf2",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358541458795000,
+      "end_unix_nano": 1785358541470604000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "5ad0d0f1085e53b6a5331ee47407f76a",
+      "span_id": "82354aa883002678",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358551509821000,
+      "end_unix_nano": 1785358551536649000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "92e25d3c2f2e41468c106db2dc762d5b",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "5ad0d0f1085e53b6a5331ee47407f76a",
+      "span_id": "238cee1e62d6784a",
+      "parent_span_id": "82354aa883002678",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358551512838000,
+      "end_unix_nano": 1785358551536182000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "f2bce9bcac7b1b44bed160ebab46e591",
+      "span_id": "e55d8d0b15f487aa",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358561559543000,
+      "end_unix_nano": 1785358561569996000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "33710858a06d4b0da16ef4b7df2e5bb5",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "f2bce9bcac7b1b44bed160ebab46e591",
+      "span_id": "fe6fa5d5e858febb",
+      "parent_span_id": "e55d8d0b15f487aa",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358561559875000,
+      "end_unix_nano": 1785358561569794000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "85c9f6a6f7222e5b33fa194a2e87a19f",
+      "span_id": "fad547a54f37d011",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358571601764000,
+      "end_unix_nano": 1785358571612635000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "497167487dac424393430b482ac78257",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "85c9f6a6f7222e5b33fa194a2e87a19f",
+      "span_id": "abed01f8ca639522",
+      "parent_span_id": "fad547a54f37d011",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358571602853000,
+      "end_unix_nano": 1785358571612114000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "be70f849beec1a30ea65408313416a65",
+      "span_id": "fb88edaa89de8e6e",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358581637855000,
+      "end_unix_nano": 1785358581668787000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "a22527ab4dd54ebebd1bfa46e8816365",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "be70f849beec1a30ea65408313416a65",
+      "span_id": "4a75c821a742b87c",
+      "parent_span_id": "fb88edaa89de8e6e",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358581638904000,
+      "end_unix_nano": 1785358581668135000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "a2f6408ba54b868b",
+      "parent_span_id": "6a1c4517ec351b98",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358582596360000,
+      "end_unix_nano": 1785358597870587000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 95
+      }
+    },
+    {
+      "trace_id": "4c93d493b4a61ec204a21f579a0287c8",
+      "span_id": "5462197bf5293757",
+      "parent_span_id": "dd8192093b179c45",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358582601356000,
+      "end_unix_nano": 1785358588823197000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "45fd37d4a72d410e8c92edb3e12b84fd",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1649,
+        "gen_ai.usage.output_tokens": 716
+      }
+    },
+    {
+      "trace_id": "1501c98f31695a193580bd944ef6ed1a",
+      "span_id": "82198648c848a741",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358591693594000,
+      "end_unix_nano": 1785358591711119000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "9d51c87068ea45579caca44bd0d9a1fe",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "1501c98f31695a193580bd944ef6ed1a",
+      "span_id": "f7aa24114c9d86b1",
+      "parent_span_id": "82198648c848a741",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358591694190000,
+      "end_unix_nano": 1785358591710873000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "cba60677c3bbf78d",
+      "parent_span_id": "9f0d650574fe2864",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358597897368000,
+      "end_unix_nano": 1785358712212122000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 75
+      }
+    },
+    {
+      "trace_id": "faf529dd83b87a68ac8a3575f500e51a",
+      "span_id": "fe97f7c3fa92cd52",
+      "parent_span_id": "6a1c4517ec351b98",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358597901146000,
+      "end_unix_nano": 1785358597919739000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "f8a09b332c1d4aa8b50779af94860500",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated"
+      }
+    },
+    {
+      "trace_id": "fbc37481763fd0ed857239482ed72658",
+      "span_id": "675c88ea1cd427e9",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358601727969000,
+      "end_unix_nano": 1785358601745023000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "36a2c17f83c74d2db6ff16917efa5d92",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "fbc37481763fd0ed857239482ed72658",
+      "span_id": "a208d256d1e33234",
+      "parent_span_id": "675c88ea1cd427e9",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358601728517000,
+      "end_unix_nano": 1785358601743646000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "66ad39884a43da35dfe2455807611976",
+      "span_id": "fc310fe54a523b1c",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611769848000,
+      "end_unix_nano": 1785358611807045000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-spare-keys",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "10c8fa27fac24363aa7a78ab111914d0",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Tomas next door has our spare keys now. He waters the plants when we travel.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000008\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 14.547215461730957
+      }
+    },
+    {
+      "trace_id": "66ad39884a43da35dfe2455807611976",
+      "span_id": "20853273afb2f871",
+      "parent_span_id": "fc310fe54a523b1c",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611771368000,
+      "end_unix_nano": 1785358611806762000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "f9e59e0d47b3a31960d3be7f1a381ae5",
+      "span_id": "d3e5523b5db79e25",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611811876000,
+      "end_unix_nano": 1785358611825195000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-physio",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "baf417acbc75448d8414fc3c0d41c1bd",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"Started physio for my right shoulder. Band work twice a day, and no overhead presses until they clear me.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000009\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 14.508598327636719
+      }
+    },
+    {
+      "trace_id": "f9e59e0d47b3a31960d3be7f1a381ae5",
+      "span_id": "13d156d4670c107c",
+      "parent_span_id": "d3e5523b5db79e25",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611812004000,
+      "end_unix_nano": 1785358611825051000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "9ed520106a8ef820717fcb2ea462c7da",
+      "span_id": "82f51542eae744c1",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611826958000,
+      "end_unix_nano": 1785358611835942000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-food-rules",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "a7e417a5b94d46b1b78a3f23bbf64c95",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"When you plan meals for me, remember I am vegetarian and I cannot stand mushrooms. No fish either.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000010\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 9.657660484313965
+      }
+    },
+    {
+      "trace_id": "9ed520106a8ef820717fcb2ea462c7da",
+      "span_id": "1551a23057b9fd6c",
+      "parent_span_id": "82f51542eae744c1",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611827053000,
+      "end_unix_nano": 1785358611835814000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "8f86927a33f5e70689633f166b0c50ea",
+      "span_id": "87809aff248100cb",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611837809000,
+      "end_unix_nano": 1785358611844812000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-morning-routine",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "adc253201d9d425894f59462878720f5",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"I run before work every morning, so breakfast ends up late, usually around ten.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000011\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 14.484249114990234
+      }
+    },
+    {
+      "trace_id": "8f86927a33f5e70689633f166b0c50ea",
+      "span_id": "006548e16a395595",
+      "parent_span_id": "87809aff248100cb",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611837891000,
+      "end_unix_nano": 1785358611844711000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "a647f19d8dd9cd046002faf31d82c269",
+      "span_id": "59384d1c9d7aac48",
+      "parent_span_id": null,
+      "name": "everos.ome.reflect_episodes",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611860510000,
+      "end_unix_nano": 1785358712340380000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "reflect_episodes",
+        "langfuse.trace.metadata.run_id": "594daddca5c642e891438d367404ef93",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.infra.ome.events:ManualTick"
+      }
+    },
+    {
+      "trace_id": "a647f19d8dd9cd046002faf31d82c269",
+      "span_id": "227c8d9300aff515",
+      "parent_span_id": "59384d1c9d7aac48",
+      "name": "everos.reflect.consolidate",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358611878501000,
+      "end_unix_nano": 1785358615845065000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "generation",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.owner_id": "alice",
+        "langfuse.trace.metadata.is_update": false,
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 400,
+        "gen_ai.usage.output_tokens": 170
+      }
+    },
+    {
+      "trace_id": "a647f19d8dd9cd046002faf31d82c269",
+      "span_id": "a39af89199539497",
+      "parent_span_id": "59384d1c9d7aac48",
+      "name": "everos.ome.extract_atomic_facts",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358615884158000,
+      "end_unix_nano": 1785358618423943000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_atomic_facts",
+        "langfuse.trace.metadata.run_id": "645e50d22b174160a82361fe6dc5b41e",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:EpisodeExtracted",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1232,
+        "gen_ai.usage.output_tokens": 221
+      }
+    },
+    {
+      "trace_id": "a647f19d8dd9cd046002faf31d82c269",
+      "span_id": "871a979b08c5842b",
+      "parent_span_id": "59384d1c9d7aac48",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358618981592000,
+      "end_unix_nano": 1785358712335376000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 170
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "75fdceda5df68baa",
+      "parent_span_id": "67d0e61beb031d20",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358712253523000,
+      "end_unix_nano": 1785358712368872000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 79
+      }
+    },
+    {
+      "trace_id": "7bfad9a9c6d8a82bc273ad5d18cca7f6",
+      "span_id": "e9bf53a903e8d49f",
+      "parent_span_id": "9f0d650574fe2864",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358712265621000,
+      "end_unix_nano": 1785358717486732000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "05d1c190d2534bcb86853bf23a34b870",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1949,
+        "gen_ai.usage.output_tokens": 406
+      }
+    },
+    {
+      "trace_id": "1dfe3162b9584e08779c66434ef481d8",
+      "span_id": "b465712a5bd2060d",
+      "parent_span_id": "67d0e61beb031d20",
+      "name": "everos.ome.extract_user_profile",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358712379489000,
+      "end_unix_nano": 1785358722766445000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "agent",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.strategy": "extract_user_profile",
+        "langfuse.trace.metadata.run_id": "3b5ec9fce6b54ba9b15186dcbec04d79",
+        "langfuse.trace.metadata.attempt": 0,
+        "langfuse.trace.metadata.event_topic": "everos.memory.events:ProfileClusterUpdated",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 2060,
+        "gen_ai.usage.output_tokens": 212
+      }
+    },
+    {
+      "trace_id": "cad8594e8eda01eeb3cdf27d16a1af5e",
+      "span_id": "1260cb5e1d5931c3",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358722790702000,
+      "end_unix_nano": 1785358722808828000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.session.id": "everos-demo-trip-booked",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "337cbd77f62f4db0a82d7a6a20f89935",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"We booked the October trip: Lisbon, a week, flying out on the 12th.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.0
+      }
+    },
+    {
+      "trace_id": "cad8594e8eda01eeb3cdf27d16a1af5e",
+      "span_id": "de548991a4a8933a",
+      "parent_span_id": "1260cb5e1d5931c3",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358722790998000,
+      "end_unix_nano": 1785358722808672000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "4bb69b6b3f404ff1c48773a104af2de9",
+      "span_id": "6a99249c4eff86ca",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358722811524000,
+      "end_unix_nano": 1785358722821675000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "1e708b9c9d9a4ab88e424550c695a36d",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "keyword",
+        "langfuse.observation.input": "{\"query\": \"October changed. We cancelled Lisbon and booked Porto instead, my sister moved the wedding there.\", \"top_k\": 1, \"method\": \"keyword\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000012\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 15.166571617126465
+      }
+    },
+    {
+      "trace_id": "4bb69b6b3f404ff1c48773a104af2de9",
+      "span_id": "90867c8638aeea43",
+      "parent_span_id": "6a99249c4eff86ca",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358722811621000,
+      "end_unix_nano": 1785358722821519000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "single_route",
+        "langfuse.trace.metadata.method": "keyword"
+      }
+    },
+    {
+      "trace_id": "b1cabaa67c329a81f8bb102c7902683e",
+      "span_id": "dd9efcf7b7e3ac46",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358722824003000,
+      "end_unix_nano": 1785358723100265000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "c35fb7f473324bacbb90f43c4d04e706",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "hybrid",
+        "langfuse.observation.input": "{\"query\": \"what happened with the October trip we booked, did the destination change after the wedding moved\", \"top_k\": 5, \"method\": \"hybrid\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000012\", \"alice_ep_20260729_00000005\", \"alice_ep_20260729_00000006\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.7631220202405513,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "b1cabaa67c329a81f8bb102c7902683e",
+      "span_id": "e49b1ccd014cd431",
+      "parent_span_id": "dd9efcf7b7e3ac46",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358722824115000,
+      "end_unix_nano": 1785358723067281000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "sparse_dense",
+        "langfuse.trace.metadata.method": "hybrid"
+      }
+    },
+    {
+      "trace_id": "b1cabaa67c329a81f8bb102c7902683e",
+      "span_id": "8ba126758fe8f7c5",
+      "parent_span_id": "e49b1ccd014cd431",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358722824165000,
+      "end_unix_nano": 1785358723039229000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 18
+      }
+    },
+    {
+      "trace_id": "b1cabaa67c329a81f8bb102c7902683e",
+      "span_id": "7357a007777b8661",
+      "parent_span_id": "dd9efcf7b7e3ac46",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358723067371000,
+      "end_unix_nano": 1785358723099656000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "hierarchy"
+      }
+    },
+    {
+      "trace_id": "988c2ba0b8fadbe829cacd6dc6f6cca9",
+      "span_id": "7e015ae53946f9aa",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358723103323000,
+      "end_unix_nano": 1785358726470220000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "d9e80da0c6e9453799de8a87d8b86ffb",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "agentic",
+        "langfuse.observation.input": "{\"query\": \"what happened with the October trip we booked, did the destination change after the wedding moved\", \"top_k\": 5, \"method\": \"agentic\"}",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1722,
+        "gen_ai.usage.output_tokens": 121,
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000012\", \"alice_ep_20260729_00000004\", \"alice_ep_20260729_00000008\", \"alice_ep_20260729_00000010\", \"alice_ep_20260729_00000002\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.987055778503418,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "988c2ba0b8fadbe829cacd6dc6f6cca9",
+      "span_id": "b1327af143621651",
+      "parent_span_id": "7e015ae53946f9aa",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358723113701000,
+      "end_unix_nano": 1785358723256984000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "988c2ba0b8fadbe829cacd6dc6f6cca9",
+      "span_id": "243c28d499b8feef",
+      "parent_span_id": "b1327af143621651",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358723113901000,
+      "end_unix_nano": 1785358723220623000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 18
+      }
+    },
+    {
+      "trace_id": "988c2ba0b8fadbe829cacd6dc6f6cca9",
+      "span_id": "168fad7dac9dc987",
+      "parent_span_id": "7e015ae53946f9aa",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358723257095000,
+      "end_unix_nano": 1785358723600654000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "cross_encoder"
+      }
+    },
+    {
+      "trace_id": "aa6e5bd577c2660bc490934b65603e8a",
+      "span_id": "ae9bfabf8dfb543e",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726478612000,
+      "end_unix_nano": 1785358726679530000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "268a2b161e334e028813103663108847",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "hybrid",
+        "langfuse.observation.input": "{\"query\": \"what did the vet say about Mochi's allergy and which food did we switch her to\", \"top_k\": 5, \"method\": \"hybrid\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000005\", \"alice_ep_20260729_00000010\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.7526292961374015,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "aa6e5bd577c2660bc490934b65603e8a",
+      "span_id": "1f8c20afca9e7d38",
+      "parent_span_id": "ae9bfabf8dfb543e",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726478795000,
+      "end_unix_nano": 1785358726654086000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "sparse_dense",
+        "langfuse.trace.metadata.method": "hybrid"
+      }
+    },
+    {
+      "trace_id": "aa6e5bd577c2660bc490934b65603e8a",
+      "span_id": "b14517a0350e20f4",
+      "parent_span_id": "1f8c20afca9e7d38",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726478854000,
+      "end_unix_nano": 1785358726616834000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 20
+      }
+    },
+    {
+      "trace_id": "aa6e5bd577c2660bc490934b65603e8a",
+      "span_id": "980f5116928502f6",
+      "parent_span_id": "ae9bfabf8dfb543e",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726654192000,
+      "end_unix_nano": 1785358726678983000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "hierarchy"
+      }
+    },
+    {
+      "trace_id": "f1de681e5cfaf4253b0dd50c96c428f0",
+      "span_id": "ffc6ea78ee56f77f",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726681818000,
+      "end_unix_nano": 1785358731795201000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "aef2e6c4eb9b46daaf9db0673e544ff7",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "agentic",
+        "langfuse.observation.input": "{\"query\": \"what did the vet say about Mochi's allergy and which food did we switch her to\", \"top_k\": 5, \"method\": \"agentic\"}",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1723,
+        "gen_ai.usage.output_tokens": 109,
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000005\", \"alice_ep_20260729_00000004\", \"alice_ep_20260729_00000010\", \"alice_ep_20260729_00000008\", \"alice_ep_20260729_00000012\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.979966938495636,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "f1de681e5cfaf4253b0dd50c96c428f0",
+      "span_id": "463ea1baea01a7e6",
+      "parent_span_id": "ffc6ea78ee56f77f",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726691055000,
+      "end_unix_nano": 1785358726912852000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "f1de681e5cfaf4253b0dd50c96c428f0",
+      "span_id": "f957d71f563bb2dc",
+      "parent_span_id": "463ea1baea01a7e6",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726691238000,
+      "end_unix_nano": 1785358726878610000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 20
+      }
+    },
+    {
+      "trace_id": "f1de681e5cfaf4253b0dd50c96c428f0",
+      "span_id": "6a1412416d7b1d76",
+      "parent_span_id": "ffc6ea78ee56f77f",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358726912969000,
+      "end_unix_nano": 1785358727324468000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "cross_encoder"
+      }
+    },
+    {
+      "trace_id": "cbdd9e554e11cc095e88eabcca5048aa",
+      "span_id": "391a7d0c8dfe67ff",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358731810132000,
+      "end_unix_nano": 1785358731964429000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "3a2ec27bd04a426a9a8b365ef1100f0d",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "hybrid",
+        "langfuse.observation.input": "{\"query\": \"why did my sourdough loaves keep coming out flat and what fixed the overnight proofing\", \"top_k\": 5, \"method\": \"hybrid\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000007\", \"alice_ep_20260729_00000010\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.8125456270642699,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "cbdd9e554e11cc095e88eabcca5048aa",
+      "span_id": "d5a07d71025c5c28",
+      "parent_span_id": "391a7d0c8dfe67ff",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358731810403000,
+      "end_unix_nano": 1785358731935013000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "sparse_dense",
+        "langfuse.trace.metadata.method": "hybrid"
+      }
+    },
+    {
+      "trace_id": "cbdd9e554e11cc095e88eabcca5048aa",
+      "span_id": "793f5e395b64b46c",
+      "parent_span_id": "d5a07d71025c5c28",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358731810501000,
+      "end_unix_nano": 1785358731907082000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 20
+      }
+    },
+    {
+      "trace_id": "cbdd9e554e11cc095e88eabcca5048aa",
+      "span_id": "9fb8de4a38e4e0e8",
+      "parent_span_id": "391a7d0c8dfe67ff",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358731935106000,
+      "end_unix_nano": 1785358731963691000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "hierarchy"
+      }
+    },
+    {
+      "trace_id": "6dfc23551eb1ac80d5e867cceefa92ed",
+      "span_id": "c05ef1f8596b26b3",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358731967394000,
+      "end_unix_nano": 1785358741335140000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "7ffb96065c474214ab4282c11969b7e1",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "agentic",
+        "langfuse.observation.input": "{\"query\": \"why did my sourdough loaves keep coming out flat and what fixed the overnight proofing\", \"top_k\": 5, \"method\": \"agentic\"}",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1724,
+        "gen_ai.usage.output_tokens": 194,
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000007\", \"alice_ep_20260729_00000004\", \"alice_ep_20260729_00000010\", \"alice_ep_20260729_00000008\", \"alice_ep_20260729_00000005\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.9756844639778137,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "6dfc23551eb1ac80d5e867cceefa92ed",
+      "span_id": "d700e3197d467c25",
+      "parent_span_id": "c05ef1f8596b26b3",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358731977783000,
+      "end_unix_nano": 1785358732141542000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "6dfc23551eb1ac80d5e867cceefa92ed",
+      "span_id": "1ae1ff55481326ae",
+      "parent_span_id": "d700e3197d467c25",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358731978018000,
+      "end_unix_nano": 1785358732099084000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 20
+      }
+    },
+    {
+      "trace_id": "6dfc23551eb1ac80d5e867cceefa92ed",
+      "span_id": "1bcf14313dbd055e",
+      "parent_span_id": "c05ef1f8596b26b3",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358732141678000,
+      "end_unix_nano": 1785358738258267000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "cross_encoder"
+      }
+    },
+    {
+      "trace_id": "1f76b8895a139e53661bcd6bc43bdd33",
+      "span_id": "8358b8f1b7a84a0b",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741354582000,
+      "end_unix_nano": 1785358741653128000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "4db1c1650a0e4cdc91ec06deca213bdb",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "hybrid",
+        "langfuse.observation.input": "{\"query\": \"which foods should you leave out when you plan my meals, I am vegetarian\", \"top_k\": 5, \"method\": \"hybrid\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000010\", \"alice_ep_20260729_00000005\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.7425618309569044,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "1f76b8895a139e53661bcd6bc43bdd33",
+      "span_id": "738b5bbe6d984dd4",
+      "parent_span_id": "8358b8f1b7a84a0b",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741354921000,
+      "end_unix_nano": 1785358741624587000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "sparse_dense",
+        "langfuse.trace.metadata.method": "hybrid"
+      }
+    },
+    {
+      "trace_id": "1f76b8895a139e53661bcd6bc43bdd33",
+      "span_id": "ece26b9476d20588",
+      "parent_span_id": "738b5bbe6d984dd4",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741355031000,
+      "end_unix_nano": 1785358741586237000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 16
+      }
+    },
+    {
+      "trace_id": "1f76b8895a139e53661bcd6bc43bdd33",
+      "span_id": "844545191007b538",
+      "parent_span_id": "8358b8f1b7a84a0b",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741624711000,
+      "end_unix_nano": 1785358741652540000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "hierarchy"
+      }
+    },
+    {
+      "trace_id": "83c98f87dd3f688be3ef07423f9dbb56",
+      "span_id": "cd57a80682faac5c",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741655608000,
+      "end_unix_nano": 1785358746203750000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "72cea10ec31d46f1997f8832700241af",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "agentic",
+        "langfuse.observation.input": "{\"query\": \"which foods should you leave out when you plan my meals, I am vegetarian\", \"top_k\": 5, \"method\": \"agentic\"}",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 1720,
+        "gen_ai.usage.output_tokens": 105,
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000010\", \"alice_ep_20260729_00000005\", \"alice_ep_20260729_00000004\", \"alice_ep_20260729_00000008\", \"alice_ep_20260729_00000012\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.905522882938385,
+        "everos.search.hit": true
+      }
+    },
+    {
+      "trace_id": "83c98f87dd3f688be3ef07423f9dbb56",
+      "span_id": "eb545d248ae62d1e",
+      "parent_span_id": "cd57a80682faac5c",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741665682000,
+      "end_unix_nano": 1785358741821516000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "83c98f87dd3f688be3ef07423f9dbb56",
+      "span_id": "97fb9f21495812ec",
+      "parent_span_id": "eb545d248ae62d1e",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741665881000,
+      "end_unix_nano": 1785358741786088000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 16
+      }
+    },
+    {
+      "trace_id": "83c98f87dd3f688be3ef07423f9dbb56",
+      "span_id": "4a77880beb3151bc",
+      "parent_span_id": "cd57a80682faac5c",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358741821628000,
+      "end_unix_nano": 1785358743678495000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "cross_encoder"
+      }
+    },
+    {
+      "trace_id": "04e7ca643e79b256003a6619d73e9dbe",
+      "span_id": "4d5c40fb74e5642b",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746226814000,
+      "end_unix_nano": 1785358746398589000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "feb1c0abbd6844cf82ce9e81b44af204",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "hybrid",
+        "langfuse.observation.input": "{\"query\": \"what did the accountant say about our tax return this year\", \"top_k\": 5, \"method\": \"hybrid\"}",
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000007\", \"alice_ep_20260729_00000004\", \"alice_ep_20260729_00000010\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.16789642601194257,
+        "everos.search.hit": false
+      }
+    },
+    {
+      "trace_id": "04e7ca643e79b256003a6619d73e9dbe",
+      "span_id": "9d981f143fe4f729",
+      "parent_span_id": "4d5c40fb74e5642b",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746227118000,
+      "end_unix_nano": 1785358746371325000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "sparse_dense",
+        "langfuse.trace.metadata.method": "hybrid"
+      }
+    },
+    {
+      "trace_id": "04e7ca643e79b256003a6619d73e9dbe",
+      "span_id": "44714fcfea619039",
+      "parent_span_id": "9d981f143fe4f729",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746227211000,
+      "end_unix_nano": 1785358746344646000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 12
+      }
+    },
+    {
+      "trace_id": "04e7ca643e79b256003a6619d73e9dbe",
+      "span_id": "03e0714836b747ff",
+      "parent_span_id": "4d5c40fb74e5642b",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746371445000,
+      "end_unix_nano": 1785358746398045000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "hierarchy"
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "622df8a01fbd0130",
+      "parent_span_id": null,
+      "name": "everos.memory.search",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746401287000,
+      "end_unix_nano": 1785358750904252000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.user.id": "alice",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.request_id": "aa80667e8c77485cbf74db0264684ed7",
+        "langfuse.trace.metadata.app_id": "default",
+        "langfuse.trace.metadata.project_id": "default",
+        "langfuse.trace.metadata.owner_type": "user",
+        "langfuse.trace.metadata.method": "agentic",
+        "langfuse.observation.input": "{\"query\": \"what did the accountant say about our tax return this year\", \"top_k\": 5, \"method\": \"agentic\"}",
+        "gen_ai.request.model": "openai/gpt-4.1-mini",
+        "gen_ai.usage.input_tokens": 3556,
+        "gen_ai.usage.output_tokens": 191,
+        "langfuse.observation.output": "{\"episodes\": [\"alice_ep_20260729_00000004\", \"alice_ep_20260729_00000005\", \"alice_ep_20260729_00000008\", \"alice_ep_20260729_00000010\", \"alice_ep_20260729_00000012\"], \"agent_cases\": [], \"agent_skills\": []}",
+        "everos.search.top_score": 0.003609895473346114,
+        "everos.search.hit": false
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "72460c472444875c",
+      "parent_span_id": "622df8a01fbd0130",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746409840000,
+      "end_unix_nano": 1785358746617415000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "707d2e63ba5c04dc",
+      "parent_span_id": "72460c472444875c",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746410036000,
+      "end_unix_nano": 1785358746577308000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 12
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "e41415de24da9aa7",
+      "parent_span_id": "622df8a01fbd0130",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358746617533000,
+      "end_unix_nano": 1785358746985676000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "cross_encoder"
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "e1016d7f4f1af607",
+      "parent_span_id": "622df8a01fbd0130",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358750184996000,
+      "end_unix_nano": 1785358750562345000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "075b4624c1fafca8",
+      "parent_span_id": "622df8a01fbd0130",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358750185304000,
+      "end_unix_nano": 1785358750566668000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "33da9f89bd57b7a5",
+      "parent_span_id": "622df8a01fbd0130",
+      "name": "everos.search.recall",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358750185632000,
+      "end_unix_nano": 1785358750557784000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "retriever",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "agentic_hybrid"
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "c323be0772205267",
+      "parent_span_id": "e1016d7f4f1af607",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358750185874000,
+      "end_unix_nano": 1785358750453070000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 6
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "fb28e1caeddd2ac3",
+      "parent_span_id": "075b4624c1fafca8",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358750188339000,
+      "end_unix_nano": 1785358750463223000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 9
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "a2a615d0f71aa335",
+      "parent_span_id": "33da9f89bd57b7a5",
+      "name": "everos.embedding",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358750189725000,
+      "end_unix_nano": 1785358750449674000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "embedding",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "gen_ai.request.model": "Qwen/Qwen3-Embedding-4B",
+        "gen_ai.usage.input_tokens": 10
+      }
+    },
+    {
+      "trace_id": "e12c7372a9b044ce692cf008d9b7704d",
+      "span_id": "a10213712c0e86bc",
+      "parent_span_id": "622df8a01fbd0130",
+      "name": "everos.search.rank",
+      "kind": "SPAN_KIND_INTERNAL",
+      "start_unix_nano": 1785358750566841000,
+      "end_unix_nano": 1785358750901430000,
+      "status": {
+        "code": "STATUS_CODE_UNSET",
+        "message": ""
+      },
+      "attributes": {
+        "langfuse.observation.type": "span",
+        "langfuse.trace.tags": [
+          "everos",
+          "memory"
+        ],
+        "langfuse.trace.metadata.phase": "cross_encoder"
+      }
+    }
+  ],
+  "scores": [
+    {
+      "traceId": "8c056ed34b024e13ec4e142481713ff2",
+      "name": "recall_top_score_raw",
+      "value": 4.411255836486816,
+      "dataType": "NUMERIC",
+      "observationId": "01b216e967be53c6",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "0d73edb2500d161b409b2b4b0413d3cd",
+      "name": "recall_top_score_raw",
+      "value": 12.67291259765625,
+      "dataType": "NUMERIC",
+      "observationId": "016d76149697b019",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "a6d4152018e5fd9a6308f1ed48353b62",
+      "name": "recall_top_score_raw",
+      "value": 9.385517120361328,
+      "dataType": "NUMERIC",
+      "observationId": "14f882904ebe3f3f",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "fe8ae362e0f5bdac1f2f2036a9edadc2",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "1e2e413c59723a9c",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "7166ed13c36d4536302f37ed0ee730cd",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "ed10ba7927540226",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "1a645b0c87775b42d37c8dd60e1992ed",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "563dc1846bab826b",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "9df82a09a4c7c556edf0ee4d1c4519e9",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "34e4ea99af0230cd",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "a6a1442729ec29f7f6be1a45e262f570",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "5438826c331308b7",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "6664d5ba28e808b6a446f4dc25b7f822",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "e2e1291064b8f373",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "0ce5c0301ad24c447f0c40686220a041",
+      "name": "recall_top_score_raw",
+      "value": 19.582921981811523,
+      "dataType": "NUMERIC",
+      "observationId": "14927c43b90bd7c1",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "577adae6fb09ef08eaa0ae275627bb39",
+      "name": "recall_top_score_raw",
+      "value": 12.041586875915527,
+      "dataType": "NUMERIC",
+      "observationId": "d9451a3aef10f6a1",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "43104f341cb3c639acbf352528a29cfe",
+      "name": "recall_top_score_raw",
+      "value": 21.879318237304688,
+      "dataType": "NUMERIC",
+      "observationId": "b20b0c7d3517c1db",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "4eb34481c50530bfc3e6ddc8dc7270cb",
+      "name": "recall_top_score_raw",
+      "value": 12.897354125976562,
+      "dataType": "NUMERIC",
+      "observationId": "75fe7828cab42bd0",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "5e168140f86eb60d00f98e60ee262ce8",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "bda45e8ec93277c9",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "add49272f8b39b6af98cd2fdc0e77203",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "175b7b618206caf2",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "5ad0d0f1085e53b6a5331ee47407f76a",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "82354aa883002678",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "f2bce9bcac7b1b44bed160ebab46e591",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "e55d8d0b15f487aa",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "85c9f6a6f7222e5b33fa194a2e87a19f",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "fad547a54f37d011",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "be70f849beec1a30ea65408313416a65",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "fb88edaa89de8e6e",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "1501c98f31695a193580bd944ef6ed1a",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "82198648c848a741",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "fbc37481763fd0ed857239482ed72658",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "675c88ea1cd427e9",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "66ad39884a43da35dfe2455807611976",
+      "name": "recall_top_score_raw",
+      "value": 14.547215461730957,
+      "dataType": "NUMERIC",
+      "observationId": "fc310fe54a523b1c",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "f9e59e0d47b3a31960d3be7f1a381ae5",
+      "name": "recall_top_score_raw",
+      "value": 14.508598327636719,
+      "dataType": "NUMERIC",
+      "observationId": "d3e5523b5db79e25",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "9ed520106a8ef820717fcb2ea462c7da",
+      "name": "recall_top_score_raw",
+      "value": 9.657660484313965,
+      "dataType": "NUMERIC",
+      "observationId": "82f51542eae744c1",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "8f86927a33f5e70689633f166b0c50ea",
+      "name": "recall_top_score_raw",
+      "value": 14.484249114990234,
+      "dataType": "NUMERIC",
+      "observationId": "87809aff248100cb",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "cad8594e8eda01eeb3cdf27d16a1af5e",
+      "name": "recall_top_score_raw",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "1260cb5e1d5931c3",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "4bb69b6b3f404ff1c48773a104af2de9",
+      "name": "recall_top_score_raw",
+      "value": 15.166571617126465,
+      "dataType": "NUMERIC",
+      "observationId": "6a99249c4eff86ca",
+      "comment": "method=keyword",
+      "metadata": {
+        "method": "keyword",
+        "calibrated": false
+      }
+    },
+    {
+      "traceId": "b1cabaa67c329a81f8bb102c7902683e",
+      "name": "recall_top_score",
+      "value": 0.7631220202405513,
+      "dataType": "NUMERIC",
+      "observationId": "dd9efcf7b7e3ac46",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "b1cabaa67c329a81f8bb102c7902683e",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "dd9efcf7b7e3ac46",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "988c2ba0b8fadbe829cacd6dc6f6cca9",
+      "name": "recall_top_score",
+      "value": 0.987055778503418,
+      "dataType": "NUMERIC",
+      "observationId": "7e015ae53946f9aa",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "988c2ba0b8fadbe829cacd6dc6f6cca9",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "7e015ae53946f9aa",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "aa6e5bd577c2660bc490934b65603e8a",
+      "name": "recall_top_score",
+      "value": 0.7526292961374015,
+      "dataType": "NUMERIC",
+      "observationId": "ae9bfabf8dfb543e",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "aa6e5bd577c2660bc490934b65603e8a",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "ae9bfabf8dfb543e",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "f1de681e5cfaf4253b0dd50c96c428f0",
+      "name": "recall_top_score",
+      "value": 0.979966938495636,
+      "dataType": "NUMERIC",
+      "observationId": "ffc6ea78ee56f77f",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "f1de681e5cfaf4253b0dd50c96c428f0",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "ffc6ea78ee56f77f",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "cbdd9e554e11cc095e88eabcca5048aa",
+      "name": "recall_top_score",
+      "value": 0.8125456270642699,
+      "dataType": "NUMERIC",
+      "observationId": "391a7d0c8dfe67ff",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "cbdd9e554e11cc095e88eabcca5048aa",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "391a7d0c8dfe67ff",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "6dfc23551eb1ac80d5e867cceefa92ed",
+      "name": "recall_top_score",
+      "value": 0.9756844639778137,
+      "dataType": "NUMERIC",
+      "observationId": "c05ef1f8596b26b3",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "6dfc23551eb1ac80d5e867cceefa92ed",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "c05ef1f8596b26b3",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "1f76b8895a139e53661bcd6bc43bdd33",
+      "name": "recall_top_score",
+      "value": 0.7425618309569044,
+      "dataType": "NUMERIC",
+      "observationId": "8358b8f1b7a84a0b",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "1f76b8895a139e53661bcd6bc43bdd33",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "8358b8f1b7a84a0b",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "83c98f87dd3f688be3ef07423f9dbb56",
+      "name": "recall_top_score",
+      "value": 0.905522882938385,
+      "dataType": "NUMERIC",
+      "observationId": "cd57a80682faac5c",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "83c98f87dd3f688be3ef07423f9dbb56",
+      "name": "recall_hit",
+      "value": 1.0,
+      "dataType": "NUMERIC",
+      "observationId": "cd57a80682faac5c",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "04e7ca643e79b256003a6619d73e9dbe",
+      "name": "recall_top_score",
+      "value": 0.16789642601194257,
+      "dataType": "NUMERIC",
+      "observationId": "4d5c40fb74e5642b",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "04e7ca643e79b256003a6619d73e9dbe",
+      "name": "recall_hit",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "4d5c40fb74e5642b",
+      "comment": "method=hybrid",
+      "metadata": {
+        "method": "hybrid",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "e12c7372a9b044ce692cf008d9b7704d",
+      "name": "recall_top_score",
+      "value": 0.003609895473346114,
+      "dataType": "NUMERIC",
+      "observationId": "622df8a01fbd0130",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    },
+    {
+      "traceId": "e12c7372a9b044ce692cf008d9b7704d",
+      "name": "recall_hit",
+      "value": 0.0,
+      "dataType": "NUMERIC",
+      "observationId": "622df8a01fbd0130",
+      "comment": "method=agentic",
+      "metadata": {
+        "method": "agentic",
+        "calibrated": true
+      }
+    }
+  ]
+}

--- a/examples/langfuse/replay.py
+++ b/examples/langfuse/replay.py
@@ -1,0 +1,215 @@
+"""Replay a recorded EverOS trace into your own Langfuse project.
+
+No EverOS install and no model API keys: this pushes a trace that a real
+EverOS server actually produced (``recorded_trace.json``, captured with
+``record_trace.py``) into your Langfuse project, so you can see what the
+integration looks like in your own UI before deciding to deploy anything.
+
+It is a recording, not a live server. Span names, attributes, token usage,
+parent/child structure and durations are EverOS's own output, replayed
+verbatim. Three things are necessarily rewritten: trace/span ids are minted
+fresh (so repeated runs do not collide), timestamps are shifted so the trace
+lands at the current time, and the root spans get a ``replay`` tag so nobody
+mistakes it for live traffic.
+
+Usage::
+
+    pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+    export LANGFUSE_SECRET_KEY="sk-lf-..."
+    export LANGFUSE_HOST="https://cloud.langfuse.com"   # US: https://us.cloud.langfuse.com
+    python replay.py
+
+To trace your own EverOS server instead, see ``README.md`` — that needs no
+replay at all, just ``[observability]`` in ``everos.toml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from typing import Any
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import (
+    Span,
+    SpanKind,
+    Status,
+    StatusCode,
+    set_span_in_context,
+)
+
+DEFAULT_HOST = "https://cloud.langfuse.com"
+REPLAY_TAG = "replay"
+
+
+def _credentials() -> tuple[str, str]:
+    """Langfuse OTLP endpoint + Basic auth header, from the standard env vars."""
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.environ.get("LANGFUSE_SECRET_KEY")
+    host = os.environ.get("LANGFUSE_HOST", DEFAULT_HOST).rstrip("/")
+    if not (public_key and secret_key):
+        sys.exit(
+            "LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY must be set "
+            "(project settings in Langfuse)."
+        )
+    token = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
+    return host, f"Basic {token}"
+
+
+def _span_kind(name: str) -> SpanKind:
+    bare = name.removeprefix("SPAN_KIND_")
+    if bare in {"", "UNSPECIFIED"}:
+        return SpanKind.INTERNAL
+    return SpanKind[bare]
+
+
+def _status(record: dict[str, Any]) -> Status | None:
+    code = record.get("code", "STATUS_CODE_UNSET").removeprefix("STATUS_CODE_")
+    if code in {"", "UNSET"}:
+        return None
+    return Status(StatusCode[code], record.get("message") or None)
+
+
+def _post_score(host: str, auth: str, payload: dict[str, Any]) -> None:
+    request = urllib.request.Request(
+        f"{host}/api/public/scores",
+        data=json.dumps(payload).encode(),
+        headers={"content-type": "application/json", "Authorization": auth},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        response.read()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", default="recorded_trace.json")
+    args = parser.parse_args()
+
+    host, auth = _credentials()
+    try:
+        with open(args.fixture, encoding="utf-8") as handle:
+            fixture = json.load(handle)
+    except FileNotFoundError:
+        sys.exit(
+            f"{args.fixture} not found. Fetch it next to this script from "
+            "https://github.com/EverMind-AI/EverOS/tree/main/examples/langfuse"
+        )
+
+    spans: list[dict[str, Any]] = fixture["spans"]
+    if not spans:
+        sys.exit(f"{args.fixture} contains no spans.")
+
+    provider = TracerProvider(resource=Resource.create(fixture.get("resource") or {}))
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(
+                endpoint=f"{host}/api/public/otel/v1/traces",
+                headers={"Authorization": auth},
+            )
+        )
+    )
+    tracer = provider.get_tracer("everos.replay")
+
+    # Land the recording at "now", preserving every relative duration.
+    offset = time.time_ns() - min(span["start_unix_nano"] for span in spans)
+
+    by_id = {span["span_id"]: span for span in spans}
+    children: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    roots: list[dict[str, Any]] = []
+    for span in spans:
+        parent = span["parent_span_id"]
+        if parent and parent in by_id:
+            children[parent].append(span)
+        else:
+            roots.append(span)
+
+    # old span id -> (new trace id hex, new span id hex), for remapping scores.
+    remapped: dict[str, tuple[str, str]] = {}
+    trace_remap: dict[str, str] = {}
+
+    def emit(record: dict[str, Any], parent: Span | None) -> None:
+        attributes = dict(record["attributes"])
+        if parent is None:
+            tags = attributes.get("langfuse.trace.tags")
+            tags = list(tags) if isinstance(tags, list) else []
+            if REPLAY_TAG not in tags:
+                tags.append(REPLAY_TAG)
+            attributes["langfuse.trace.tags"] = tags
+            recorded_at = fixture.get("recorded_at")
+            if recorded_at:
+                attributes["langfuse.trace.metadata.replay_of"] = recorded_at
+
+        span = tracer.start_span(
+            record["name"],
+            context=set_span_in_context(parent) if parent is not None else None,
+            kind=_span_kind(record["kind"]),
+            start_time=record["start_unix_nano"] + offset,
+            attributes=attributes,
+        )
+        context = span.get_span_context()
+        remapped[record["span_id"]] = (
+            format(context.trace_id, "032x"),
+            format(context.span_id, "016x"),
+        )
+        trace_remap.setdefault(record["trace_id"], format(context.trace_id, "032x"))
+
+        for child in children[record["span_id"]]:
+            emit(child, span)
+
+        status = _status(record["status"])
+        if status is not None:
+            span.set_status(status)
+        span.end(end_time=record["end_unix_nano"] + offset)
+
+    for root in roots:
+        emit(root, None)
+
+    provider.force_flush()
+    provider.shutdown()
+    print(f"Replayed {len(spans)} span(s) in {len(roots)} trace(s) to {host}")
+
+    sent = 0
+    skipped = 0
+    for score in fixture.get("scores", []):
+        payload = dict(score)
+        observation = score.get("observationId")
+        if observation and observation in remapped:
+            trace_id, span_id = remapped[observation]
+            payload["traceId"] = trace_id
+            payload["observationId"] = span_id
+        elif score.get("traceId") in trace_remap:
+            payload["traceId"] = trace_remap[score["traceId"]]
+            payload.pop("observationId", None)
+        else:
+            skipped += 1
+            continue
+        try:
+            _post_score(host, auth, payload)
+            sent += 1
+        except urllib.error.HTTPError as exc:
+            print(f"  ! score {score.get('name')} rejected: {exc}", file=sys.stderr)
+    if sent or skipped:
+        note = f", {skipped} unmapped" if skipped else ""
+        print(f"Pushed {sent} recall score(s){note}")
+
+    print(
+        "\nOpen Langfuse -> Tracing and filter on the 'replay' tag. "
+        "This is a recorded EverOS run, not a live server: "
+        "see README.md to trace your own."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langfuse/replay.py
+++ b/examples/langfuse/replay.py
@@ -51,6 +51,9 @@ from opentelemetry.trace import (
 
 DEFAULT_HOST = "https://cloud.langfuse.com"
 REPLAY_TAG = "replay"
+SCORE_MAX_ATTEMPTS = 5
+# Small gap between scores; cheaper than discovering the limiter one 429 at a time.
+SCORE_PACE_SECONDS = 0.15
 
 
 def _credentials() -> tuple[str, str]:
@@ -65,6 +68,37 @@ def _credentials() -> tuple[str, str]:
         )
     token = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
     return host, f"Basic {token}"
+
+
+def _check_credentials(host: str, auth: str) -> None:
+    """Fail fast, and say why, before pushing a few hundred spans.
+
+    Langfuse keys are region-scoped, and the OTLP exporter only reports a
+    rejected export through the SDK's own logging, so a wrong host otherwise
+    looks like a successful run into an empty project.
+    """
+    request = urllib.request.Request(
+        f"{host}/api/public/projects", headers={"Authorization": auth}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code not in {401, 403}:
+            # Only auth is under test; any other response is the replay's problem.
+            return
+        other = (
+            "https://cloud.langfuse.com"
+            if "us." in host
+            else "https://us.cloud.langfuse.com"
+        )
+        sys.exit(
+            f"{host} rejected these keys ({exc.code}). Langfuse projects are "
+            f"region-scoped, so if the project lives in the other region set "
+            f"LANGFUSE_HOST={other} and try again."
+        )
+    except OSError:
+        return  # unreachable host surfaces on the real export a moment later
 
 
 def _span_kind(name: str) -> SpanKind:
@@ -82,14 +116,29 @@ def _status(record: dict[str, Any]) -> Status | None:
 
 
 def _post_score(host: str, auth: str, payload: dict[str, Any]) -> None:
+    """POST one score, backing off when Langfuse rate-limits the endpoint.
+
+    Scores go one per request, so replaying a whole recording sends dozens in a
+    row and reliably trips the limiter without this.
+    """
     request = urllib.request.Request(
         f"{host}/api/public/scores",
         data=json.dumps(payload).encode(),
         headers={"content-type": "application/json", "Authorization": auth},
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=10) as response:
-        response.read()
+    for attempt in range(SCORE_MAX_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                response.read()
+            return
+        except urllib.error.HTTPError as exc:
+            retryable = exc.code == 429 or 500 <= exc.code < 600
+            if not retryable or attempt == SCORE_MAX_ATTEMPTS - 1:
+                raise
+            after = exc.headers.get("retry-after") if exc.headers else None
+            delay = float(after) if after and after.isdigit() else 2.0**attempt
+            time.sleep(delay)
 
 
 def main() -> None:
@@ -98,6 +147,7 @@ def main() -> None:
     args = parser.parse_args()
 
     host, auth = _credentials()
+    _check_credentials(host, auth)
     try:
         with open(args.fixture, encoding="utf-8") as handle:
             fixture = json.load(handle)
@@ -200,6 +250,7 @@ def main() -> None:
             sent += 1
         except urllib.error.HTTPError as exc:
             print(f"  ! score {score.get('name')} rejected: {exc}", file=sys.stderr)
+        time.sleep(SCORE_PACE_SECONDS)
     if sent or skipped:
         note = f", {skipped} unmapped" if skipped else ""
         print(f"Pushed {sent} recall score(s){note}")


### PR DESCRIPTION
## Why

Native OTel moved span emission into the server, which cost the Langfuse example its try-before-install path: since 1.2.0, seeing anything at all requires a configured EverOS with an LLM behind it. The live cookbook page still tells readers to copy `everos_langfuse.py`, a file that no longer exists.

This restores a zero-install path without fabricating anything, and makes the demo produce traces that show behaviour rather than plumbing.

## `replay.py` — no EverOS, no model keys

Pushes a recording of a real EverOS run into the reader's own Langfuse project. Span names, attributes, token usage, parent/child structure and durations are replayed verbatim; only three things are rewritten, and the README says so: ids are minted fresh, timestamps shift to now, and root spans carry a `replay` tag.

Two failure modes found while testing against real Langfuse, both fixed here:

- the scores API rate-limits, and posting 47 scores in a tight loop lost 18 of them to `429`. Now retries with backoff, honouring `Retry-After`, and paces sends. 47/47 land.
- Langfuse keys are region-scoped, and a wrong `LANGFUSE_HOST` fails *silently*: the OTLP exporter only complains through SDK logging, so the script printed success into an empty project. A pre-flight credential check now names the other region. It only treats 401/403 as fatal, so it cannot become a host-validity gate.

## `record_trace.py` — how the recording was made

Stands in for Langfuse's OTLP and scores endpoints on localhost. This works because EverOS derives both from `langfuse_host`, so one sink captures both signals straight from a real server run. Nothing in the fixture is synthesized.

## `demo.py` — a memory worth searching

It used to ingest one conversation and search it, so recall had nothing to choose between.

Eleven short conversations now span ten weeks, each on its own topic. Two revisit the same subject five days apart, close enough for geometry clustering to group them, which finally gives reflection something to consolidate: the demo nudges `reflect_episodes` (a `0 2 * * 1` cron otherwise), waits for the merge to land, and the superseded memory is gone from search before the questions are asked. One question asks about something never discussed.

Recall on the resulting store, from the recorded run:

| question | HYBRID | AGENTIC |
| --- | --- | --- |
| the October trip and its revision | 0.763 | 0.987 |
| what the vet said about the cat | 0.753 | 0.980 |
| why the sourdough kept coming out flat | 0.813 | 0.976 |
| which foods to leave out of meal planning | 0.743 | 0.906 |
| **something never discussed** | **0.168** | **0.004** |

Two sequencing bugs had to be fixed to get there, and both would bite anyone driving EverOS from a script:

- a fixed sleep after `flush` searched a half-built index. Readiness is now polled per session. Polling is deliberately slack, because every probe is itself a traced search and a tight loop buried the real questions under readiness checks.
- `/ome/trigger` returns once the OME engine is idle, but the merge reaches LanceDB through the cascade, and deprecating the old episodes is a separate write from indexing the merged one. Querying in between saw neither and scored 0.55 where the memory deserved 0.76. The demo now waits for both edges.

KEYWORD is no longer a demonstrated method: its top score is raw BM25, on a different scale from the calibrated ones, so showing the three side by side invited a comparison that means nothing. It still runs as the readiness probe.

## The recording

`recorded_trace.json`, one `demo.py` run against 1.2.1: 237 spans over 60 traces, zero error spans, no secrets, no absolute paths, synthetic content throughout. Includes `everos.reflect.consolidate` under `everos.ome.reflect_episodes`.

Agent cases and skills are deliberately absent. Exercising them needs a tool-call trajectory, and that path has open issues (agent-case extraction requires >= 3 tool-call rounds; AGENTIC search over agent-owned memory 500s; the case-to-skill chain races the LanceDB sync). The span and score contract is identical when they appear, so a later re-record is a fixture swap.

## Verification

Replayed into real Langfuse (60 traces, 47 scores, $0.07 of cost computed by Langfuse from our token attributes) and round-tripped through the recorder offline, asserting span count, name multiset, isomorphic parent/child edges, preserved durations and token usage, fresh non-colliding ids, every score remapped onto a replayed span, and the `replay` tag on roots only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyKinsWs1MgoARPoB9R4NW