### PR TITLE
docs(security): refresh policy and link published advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-EverOS is released and at v1.0.0 (stable). Security fixes are applied to the
-latest release line only.
+Security fixes are applied to the latest release line only; older minor lines do
+not receive backports.
 
 | Version | Supported |
 |---------|-----------|
-| 1.x     | ✅        |
-| < 1.0   | ❌        |
+| `1.2.x` (current) | ✅ |
+| `1.1.x` and older | ❌ — upgrade to the current line |
 
 ## Reporting a Vulnerability
 
@@ -24,8 +24,18 @@ Instead, email **evermind@shanda.com** with:
 
 We will acknowledge your report within **5 business days**, keep you informed of
 progress, and aim to ship a fix or mitigation before any public disclosure.
-Reporters are credited in the release notes unless you prefer to remain
-anonymous.
+Reporters are credited in the advisory and the release notes unless you prefer
+to remain anonymous.
+
+## Published Advisories
+
+Confirmed issues are published as GitHub Security Advisories, each carrying the
+affected version ranges and the release that fixes them:
+
+<https://github.com/EverMind-AI/EverOS/security/advisories>
+
+To check whether an installation is affected by a past issue, read the version
+range on the advisory itself — the range is authoritative.
 
 ## Scope & Threat Model
 
@@ -39,6 +49,10 @@ following in mind:
   is loopback-only. Only set the bind to `0.0.0.0` (or any routable interface)
   after you have placed your own gateway / auth layer in front;
   `everos server start` will log a warning when you bind to `0.0.0.0`.
+- **Documents you ingest are untrusted input.** Filenames, metadata, and
+  content that originate outside your control are parsed, indexed, and written
+  to disk. An instance that ingests third-party documents is processing
+  untrusted data even when the API itself is reachable only from loopback.
 - Secrets (LLM / embedding API keys) live in your local `.env`; protect that
   file as you would any credential. EverOS never transmits them anywhere except
   the providers you configure.


### PR DESCRIPTION
## Summary

`SECURITY.md` had drifted: the supported-versions section still read "EverOS is
released and at v1.0.0 (stable)" and listed all of `1.x` as supported, two minor
releases behind. This refreshes it and fills two gaps that
[GHSA-grm3-hcqf-hm28](https://github.com/EverMind-AI/EverOS/security/advisories/GHSA-grm3-hcqf-hm28)
made visible.

- **Supported versions** are now expressed as a *line* (`1.2.x (current)`)
  rather than a pinned patch number, so the section does not go stale on the
  next release — which is how the old text ended up two minors behind.
- **New "Published Advisories" section** pointing at `/security/advisories`,
  with a note to read the affected range on the advisory rather than comparing
  version numbers. Ranges are not always a simple "everything below X".
- **New threat-model bullet: ingested documents are untrusted input.** The
  existing first bullet covers *who can call the API* (loopback-only by
  default). It does not cover the case where the caller is trusted but the
  filenames, metadata, and content it forwards are not — which is the shape of
  the traversal fixed in 1.2.1.
- Reporters are credited in the advisory as well as the release notes, matching
  what we actually do.

Reporting stays **email-only**. GitHub private vulnerability reporting is
deliberately left disabled: the documented 5-business-day acknowledgement is
easier to honour through one monitored inbox than through GitHub notifications
on this repo.

## Area

- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [x] Documentation
- [ ] Developer experience
- [ ] CI, build, or release

## Verification

```text
python3 scripts/check_commit_messages.py HEAD^..HEAD   -> pass
No line in the diff exceeds 80 columns (matches surrounding style).
Advisory URL resolves; no relative links added.
Documentation-only change; no code or tests affected.
```

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [x] I added or updated tests when the change affects behavior. (N/A — docs only)
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

The supported-versions table is a **policy statement**, so it is worth an
explicit look: it now says `1.1.x` and older receive no backports. That matches
the previous wording ("applied to the latest release line only") and the current
reality that this repository has no maintenance branches — only `main`. If the
intent is to keep patching a `1.1.x` line, this table needs to say so instead.

By submitting this pull request, I agree that my contribution is licensed under
the Apache License 2.0.
