### PR TITLE
ci: draft the GitHub Release page from the CHANGELOG on tag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -45,11 +45,25 @@ section fails the release job for the same reason.
 
 ## The release page
 
-The body comes from the CHANGELOG section verbatim (`### Added` demoted to
-`## Added`). What CI cannot write is the **lead summary**: the two or three
-sentences above the first heading that say what this release is for, in prose
-— see [1.2.1](https://github.com/EverMind-AI/EverOS/releases/tag/v1.2.1) for
-the shape. Write it before publishing.
+Every page has the same shape:
+
+```
+<lead summary>          prose — CI cannot write this
+## Added / ## Changed / ## Fixed / ...    from the CHANGELOG section, verbatim
+## Upgrade              pip line + compare link prefilled; migration notes by hand
+```
+
+Two parts are yours to write in the draft:
+
+- **The lead summary** — the two or three sentences above the first heading
+  saying what this release is for.
+- **Migration notes in `## Upgrade`**, when the release has any: what happens on
+  the first startup after upgrading, which command recovers a bad state, which
+  pins moved. Skip when a plain `pip install --upgrade` is genuinely all there
+  is; do not invent filler.
+
+See [1.2.1](https://github.com/EverMind-AI/EverOS/releases/tag/v1.2.1) for the
+shape of both.
 
 > While it is a draft, GitHub serves the release at
 > `releases/tag/untagged-<hash>`, and that URL keeps serving a stale page after

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -8,7 +8,12 @@ description: Cut a versioned release and publish everos to PyPI via the tag-trig
 Publish a new version of `everos` to PyPI. Publishing is automated: pushing a
 `vX.Y.Z` tag triggers [.github/workflows/release.yml](../../../.github/workflows/release.yml),
 which builds, smoke-tests, and uploads via PyPI **Trusted Publishing** (OIDC —
-no stored token) behind the `release` environment's manual-approval gate.
+no stored token) behind the `release` environment's manual-approval gate, then
+drafts the GitHub Release page from the CHANGELOG.
+
+A release is not finished when PyPI accepts the upload: the GitHub Release page
+is drafted, never auto-published, and someone has to write its lead summary and
+click **Publish**.
 
 ## Preconditions
 
@@ -29,16 +34,41 @@ no stored token) behind the `release` environment's manual-approval gate.
 6. Approve             → the release.yml run pauses on the `release`
    environment; a reviewer approves in the Actions run
 7. Verify              → https://pypi.org/project/everos/X.Y.Z/
+8. Publish the page    → the run leaves a DRAFT GitHub Release titled
+   "EverOS X.Y.Z", body prefilled from the CHANGELOG section. Write the lead
+   summary at the top, then click Publish.
 ```
 
 The tag must equal the `pyproject.toml` version — the workflow refuses to
-publish on a mismatch.
+publish on a mismatch. A stable tag with no matching `## [X.Y.Z]` CHANGELOG
+section fails the release job for the same reason.
+
+## The release page
+
+The body comes from the CHANGELOG section verbatim (`### Added` demoted to
+`## Added`). What CI cannot write is the **lead summary**: the two or three
+sentences above the first heading that say what this release is for, in prose
+— see [1.2.1](https://github.com/EverMind-AI/EverOS/releases/tag/v1.2.1) for
+the shape. Write it before publishing.
+
+> While it is a draft, GitHub serves the release at
+> `releases/tag/untagged-<hash>`, and that URL keeps serving a stale page after
+> publication with no redirect. Never share it — a reader who opens it later
+> concludes the release never went out. Link `releases/tag/vX.Y.Z` instead; the
+> job prints both URLs in its step summary.
+
+Re-running the release job replaces its own draft and leaves an already-published
+release untouched, so a re-run is always safe.
 
 ## Pre-releases
 
 PEP 440 pre-release tags publish too (PyPI accepts them; `pip install everos`
 ignores them unless `--pre`): `vX.Y.ZrcN`, `vX.Y.ZaN`, `vX.Y.ZbN`. Set the same
 suffix in `pyproject.toml` version before tagging.
+
+Their release page is drafted as a **pre-release** and never becomes
+`/releases/latest`. A pre-release does not need its own CHANGELOG section — the
+draft falls back to a one-line placeholder body when there is none.
 
 ## One-time setup (project owner, not doable from CI)
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -71,6 +71,17 @@ shape of both.
 > concludes the release never went out. Link `releases/tag/vX.Y.Z` instead; the
 > job prints both URLs in its step summary.
 
+Publish with the **Publish release** button in the web UI. Publishing through
+the API by flipping `draft` alone drops the tag: GitHub rebinds the release to
+the `untagged-<hash>` placeholder and creates a git tag by that name against the
+default branch (observed on 1.2.2). Pass `tag_name` if you must do it from the
+CLI:
+
+```bash
+gh api -X PATCH "repos/EverMind-AI/EverOS/releases/<id>" \
+  -F draft=false -f tag_name=vX.Y.Z -f make_latest=true
+```
+
 Re-running the release job replaces its own draft and leaves an already-published
 release untouched, so a re-run is always safe.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,16 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # the whole tag list, to name the previous release
 
       - name: Build the notes from CHANGELOG.md
         env:
           TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
           python3 - <<'PY'
-          import os, pathlib, re, sys
+          import os, pathlib, re, subprocess, sys
 
           tag = os.environ["TAG"]
           version = tag[1:]
@@ -104,6 +107,25 @@ jobs:
               # Demote the Keep-a-Changelog `### Added` group headings to `##`,
               # matching how every earlier EverOS release page is structured.
               body = re.sub(r"^### ", "## ", match.group(1).strip(), flags=re.M) + "\n"
+
+          # Every EverOS release page since 1.1.3 closes with an Upgrade
+          # section. Only its boilerplate is prefilled here — a release that
+          # needs migration notes gets them written into the draft by hand.
+          tags = subprocess.run(
+              ["git", "tag", "--list", "v*", "--sort=-v:refname"],
+              capture_output=True, text=True, check=True,
+          ).stdout.split()
+          previous = None
+          if tag in tags:
+              previous = next(
+                  (t for t in tags[tags.index(tag) + 1:] if re.fullmatch(r"v\d+\.\d+\.\d+", t)),
+                  None,
+              )
+
+          body += "\n## Upgrade\n\n```bash\npip install --upgrade everos   # or: uv sync\n```\n"
+          if previous is not None:
+              compare = f"https://github.com/{os.environ['REPO']}/compare/{previous}...{tag}"
+              body += f"\n**Full changelog:** [{previous}...{tag}]({compare})\n"
 
           notes = pathlib.Path(os.environ["RUNNER_TEMP"]) / "notes.md"
           notes.write_text(body, encoding="utf-8")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-# Publishes to PyPI via Trusted Publishing (OIDC) — no stored token.
+# Publishes to PyPI via Trusted Publishing (OIDC) — no stored token — and then
+# drafts the matching GitHub Release page from CHANGELOG.md.
 # Fires on a version tag (vX.Y.Z, plus PEP 440 pre-releases vX.Y.ZrcN / aN / bN).
 # The `release` environment gates the upload behind manual approval; configure
 # required reviewers under Settings → Environments → release.
@@ -54,3 +55,113 @@ jobs:
 
       - name: Publish to PyPI (Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  # The notes page is a separate job so the publish job above keeps
+  # `contents: read` next to its OIDC token. It runs only after PyPI accepted
+  # the upload — a release page for a version nobody can install is worse than
+  # no page. The release is left as a DRAFT: the CHANGELOG section gives the
+  # body, but the lead summary that opens every EverOS release page is written
+  # by a human, who then clicks Publish.
+  github-release:
+    name: draft the GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build the notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          python3 - <<'PY'
+          import os, pathlib, re, sys
+
+          tag = os.environ["TAG"]
+          version = tag[1:]
+          # vX.Y.Z is stable; anything with a PEP 440 suffix (rc1 / a1 / b1 /
+          # .dev1) is a pre-release and must never become /releases/latest.
+          prerelease = re.fullmatch(r"\d+\.\d+\.\d+", version) is None
+
+          src = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          match = re.search(
+              # Stops at the next version heading, at the link-reference block
+              # that closes the file, or at EOF.
+              rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|^\[[^\]]+\]: |\Z)",
+              src,
+              re.S | re.M,
+          )
+          if match is None and not prerelease:
+              # A stable release with no CHANGELOG entry is a mistake in the
+              # release PR, not something to paper over with an empty page.
+              print(f"::error::CHANGELOG.md has no '## [{version}]' section")
+              sys.exit(1)
+
+          if match is None:
+              body = f"Pre-release build of `{version}`. See CHANGELOG.md on the tag.\n"
+          else:
+              # Demote the Keep-a-Changelog `### Added` group headings to `##`,
+              # matching how every earlier EverOS release page is structured.
+              body = re.sub(r"^### ", "## ", match.group(1).strip(), flags=re.M) + "\n"
+
+          notes = pathlib.Path(os.environ["RUNNER_TEMP"]) / "notes.md"
+          notes.write_text(body, encoding="utf-8")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env:
+              env.write(f"RELEASE_VERSION={version}\n")
+              env.write(f"RELEASE_NOTES={notes}\n")
+              env.write(f"RELEASE_PRERELEASE={'true' if prerelease else 'false'}\n")
+          PY
+
+      - name: Create the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Find an existing release through the LIST endpoint: the by-tag
+          # endpoint is published-only, so the Actions token cannot see a draft
+          # through it (cli/cli#3037) and a re-run would 422 on create. Replace
+          # a stale draft (deleting a draft keeps the git tag); never touch a
+          # release someone already published.
+          rel="$(gh api "repos/$REPO/releases?per_page=100" \
+            --jq "map(select(.tag_name == \"$TAG\"))[0] // {}")"
+          id="$(printf '%s' "$rel" | jq -r '.id // empty')"
+          draft="$(printf '%s' "$rel" | jq -r '.draft // false')"
+
+          if [ -n "$id" ] && [ "$draft" != "true" ]; then
+            echo "Release $TAG is already published; leaving it alone."
+            echo "Release $TAG already published: https://github.com/$REPO/releases/tag/$TAG" \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ -n "$id" ]; then
+            gh api -X DELETE "repos/$REPO/releases/$id"
+          fi
+
+          # Written as `if`, not `cond && assign`: the runner's shell is
+          # `bash -e`, where a false test at the head of an AND-OR list fails
+          # the whole step.
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            flags="--prerelease --latest=false"
+          else
+            flags="--latest"
+          fi
+          # $flags is deliberately unquoted — it carries two words.
+          draft_url="$(gh release create "$TAG" \
+            --draft $flags \
+            --title "EverOS $RELEASE_VERSION" \
+            --notes-file "$RELEASE_NOTES")"
+
+          # A draft lives at releases/tag/untagged-<hash> and keeps serving that
+          # stale page after publication, with no redirect to the real tag. Print
+          # both URLs so nobody shares the draft one by copying the address bar.
+          {
+            echo "### Release $TAG (draft)"
+            echo ""
+            echo "Write the lead summary in the draft, then click **Publish**."
+            echo ""
+            echo "- Draft (temporary, do not share): $draft_url"
+            echo "- Public URL once published: https://github.com/$REPO/releases/tag/$TAG"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

`release.yml` only published to PyPI. Creating the GitHub Release page was a manual step that no workflow performed and no doc mentioned — so `v1.2.2` went out to PyPI with no release page, which is what prompted this.

A second job now drafts the page after a successful upload:

- Title `EverOS X.Y.Z`; body lifted from the matching `## [X.Y.Z]` CHANGELOG section, with the `### Added` group headings demoted to `##` to match the existing pages.
- `--prerelease --latest=false` for PEP 440 suffixed tags, so an rc can never become `/releases/latest`.
- Left as a **draft**: the lead summary that opens every EverOS release page is prose CI cannot write. The step summary prints both the draft URL and the eventual public one.

Design notes:

- Separate job so the publish job keeps `contents: read` next to its OIDC token, and so no page appears for a version that failed to upload.
- A stable tag with no CHANGELOG section **fails** the job instead of publishing an empty page. Pre-releases fall back to a placeholder body.
- Existing releases are detected through the list endpoint: the by-tag endpoint is published-only, so the Actions token cannot see a draft through it ([cli/cli#3037](https://github.com/cli/cli/issues/3037)) and a re-run would 422. A stale draft is replaced; a published release is left alone.

This mirrors what [Raven](https://github.com/EverMind-AI/Raven) has done for ten releases, with the body sourced from the CHANGELOG rather than a mostly-TODO template.

## Area

- [x] CI, build, or release

## Verification

Both steps were extracted from the workflow YAML and executed locally — the extraction step against the real `CHANGELOG.md`, the shell step under `bash -e` against a stubbed `gh`.

```text
extraction (real CHANGELOG.md)
  v1.2.2     rc=0  7887 chars  headings: ## Added / ## Changed / ## Fixed / ## Docs
  v1.1.4     rc=0  3046 chars
  v1.0.0     rc=0  1163 chars  (stops before the link-reference block)
  v9.9.9     rc=1  ::error::CHANGELOG.md has no '## [9.9.9]' section
  v1.2.3rc1  rc=0  prerelease=true, placeholder body

shell step under `bash -e`, stubbed gh, 3 states x stable/pre-release
  no release   -> create --draft --latest            rc=0
  no release   -> create --draft --prerelease --latest=false  rc=0
  stale draft  -> DELETE releases/42, then create    rc=0
  published    -> no write calls, summary line only  rc=0
```

The first draft of the shell step used `[ cond ] && assign`, which fails a `bash -e` step when the test is false; the stubbed run caught it and it is now an `if`.

`v1.2.2`'s page was created by hand from the same CHANGELOG section this job extracts, as a draft awaiting its lead summary.

## Checklist

- [x] I kept the change scoped to the relevant area.
- [x] I am opening this from a separate branch, not pushing directly to `main`.
- [x] I updated docs, examples, or setup notes when behavior changed.
- [ ] I added or updated tests when the change affects behavior.
- [x] I did not commit secrets, `.env` files, dependency folders, or generated output.
- [x] Active relative links in Markdown files resolve.

## Notes for Reviewers

`/release` gains a step 8 (write the lead summary, click Publish) and a warning about the `releases/tag/untagged-<hash>` draft URL, which keeps serving a stale page after publication with no redirect.

The workflow can only be exercised for real by pushing a tag. If you would rather validate it end to end before the next release, a throwaway `v1.2.3rc1` tag exercises the whole path without touching `/releases/latest` — the rc release and tag get deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
