### PR TITLE
docs(lancedb): mark the husk sweep removable once lance#8322 ships

### DIFF
--- a/src/everos/core/persistence/lancedb/repository.py
+++ b/src/everos/core/persistence/lancedb/repository.py
@@ -103,6 +103,16 @@ a day sits four orders of magnitude below it (tens of MB). Platform-wise only
 ext4 has a fixed inode budget at all; APFS and xfs allocate dynamically, and
 Windows is out of scope. The knob to reach for if this ever does bite is the
 optimize cooldown, not this threshold — see there.
+
+**When to remove this sweep** — lance-format/lance#8322 (merged 2026-08-06,
+not in any release as of lancedb 0.34.0 / lance 8.0.0 — the merge sits ahead of
+v11.0.0-beta.2) makes lance's own cleanup remove the directories it empties,
+under this same 7-day / ``delete_unverified`` policy. Once a release carrying
+it is pinned, delete :func:`_remove_empty_index_dirs` and its call site rather
+than keep a second implementation of upstream's rule. That upgrade also halves
+the horizon above: lance drops the directory in the pass that empties it, so
+our age gate stops stacking on top of theirs and the steady state goes from
+~14 days back to ~7.
 """
 
 _HUSK_SWEEP_TIMEOUT_SECONDS = 60.0


### PR DESCRIPTION
Follow-up to #392. Upstream acted on one of the two issues that PR's investigation produced.

[lance-format/lance#8320](https://github.com/lance-format/lance/issues/8320) — `cleanup_old_versions` unlinks a superseded index's files but never removes the directory — was fixed by [lance#8322](https://github.com/lance-format/lance/pull/8322), merged 2026-08-06. It removes the emptied directories under the same 7-day / `delete_unverified` policy that `_remove_empty_index_dirs` reimplements on our side.

The fix is **not in any release yet**: lancedb 0.34.0 embeds lance 8.0.0, and the merge commit sits ahead of v11.0.0-beta.2. So the sweep stays for now. This records why it should not stay forever, next to the code rather than in a chat log.

Two consequences worth having written down at the point of use:

- **Delete, don't keep both.** Once a pin carries #8322, `_remove_empty_index_dirs` and its call site should go — a second implementation of upstream's own rule is the kind of thing that survives for years because nobody remembers it was a workaround.
- **The documented horizon halves.** The constant currently explains a ~14-day steady state, because lance frees the *files* at 7 days, which resets the directory's mtime, and only then does our 7-day gate start. Upstream drops the directory in the same pass that empties it, so the two windows stop stacking and it goes back to ~7 days (~890k dirs / ~3.6GB at ceiling load, from ~1.8M / ~7GB).

Docs only — no behaviour change. `ruff` clean, 1938 unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)