### PR TITLE
docs(readme): streamline demo quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,31 +105,17 @@ uv pip install everos
 
 ### 2. Try the standalone demo — no key required
 
-Before configuring a provider or starting the server, run:
+No API key or server setup required—run one command to quickly experience how
+EverOS stores and recalls memory:
 
 ```bash
 everos demo
 ```
 
-The full-screen terminal UI has an input box: type something EverOS should
-remember, then ask a question that recalls it. No API key or server setup is
-needed. Each round lets you watch the memory move through the real lifecycle:
-ingest -> extract -> index -> recall.
-
-The particle sphere changes with each stage, then bursts across the memory
-field and fades away. A small core of yellow and white particles keeps moving
-at the center, then expands smoothly into the next round. See
-[docs/everos-demo.md](docs/everos-demo.md) for the complete experience. Type
-`/` to see the commands (`/replay`, `/live`, `/quit`); `ctrl+c` exits anytime.
-After a few rounds the demo points you at configuring your own keys (`everos
-init`, then `everos demo --live`).
+Enter something EverOS should remember, then ask a related question to watch
+the memory move through ingest -> extract -> index -> recall.
 
 <https://github.com/user-attachments/assets/98cb8e1e-2ca8-4504-b0a6-0b9a040a0a5c>
-
-Press `r` to replay and `q` to quit. For a non-interactive preview, use
-`everos demo --plain`; for the looping showroom view, use
-`everos demo --cinematic`. See [docs/everos-demo.md](docs/everos-demo.md) for
-the visualizer's scope.
 
 ### 3. Initialize and add your OpenRouter key
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,27 +105,17 @@ uv pip install everos
 
 ### 2. 先体验独立 Demo —— 不需要 Key
 
-在配置 provider 或启动 server 之前，先运行：
+无需填写 API Key 或启动 server，只需一条命令即可快速体验 EverOS 如何保存并
+召回记忆：
 
 ```bash
 everos demo
 ```
 
-全屏 terminal UI 里带有一个输入框：先输入一件希望 EverOS 记住的事情，再提出
-一个能够召回它的问题。不需要 API key，也不需要提前启动 server。每一轮都能
-直观看到记忆经历完整流程：ingest -> extract -> index -> recall。
-
-粒子球会随四个阶段持续变化，随后散落到 memory field 并淡出；中心会先留下少量
-黄白粒子攒动，再由中心向外扩展成完整球体，进入下一轮。完整体验见
-[docs/everos-demo.md](docs/everos-demo.md)。输入 `/` 可以
-查看可用命令（`/replay`、`/live`、`/quit`）；`ctrl+c` 随时退出。几轮之后，demo
-会引导你配置自己的 key（`everos init`，然后 `everos demo --live`）。
+输入一条希望 EverOS 记住的信息，再提出相关问题，即可直观看到记忆经过
+ingest -> extract -> index -> recall 的完整流程。
 
 <https://github.com/user-attachments/assets/98cb8e1e-2ca8-4504-b0a6-0b9a040a0a5c>
-
-按 `r` replay，按 `q` 退出。非交互式预览可以使用 `everos demo --plain`；
-循环 showroom view 可以使用 `everos demo --cinematic`。Visualizer 的范围见
-[docs/everos-demo.md](docs/everos-demo.md)。
 
 ### 3. 初始化并配置百炼
 


### PR DESCRIPTION
## What changed

- Shorten the standalone demo section in both English and Chinese READMEs.
- Keep only the one-command quickstart, a concise explanation of the memory flow, and the demo video.
- Emphasize that no API key or server setup is required.

## Why

The previous section repeated animation details, command references, and documentation links before readers reached the demo. The shorter copy makes the first-run path easier to scan.

## Validation

- `git diff --check`
- `python3 scripts/check_repo_assets.py`
- `python3 scripts/check_file_sizes.py`
