### PR TITLE
fix: render demo sphere with depth perspective

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,11 @@ No API key or server setup required—run one command to quickly experience how
 EverOS stores and recalls memory:
 
 ```bash
+# If you installed EverOS as a package:
 everos demo
+
+# If you cloned or forked this repository and have not activated .venv:
+uv run everos demo
 ```
 
 Enter something EverOS should remember, then ask a related question to watch
@@ -273,11 +277,10 @@ sudo apt-get install -y libreoffice          # Debian / Ubuntu
 git clone https://github.com/EverMind-AI/EverOS.git
 cd EverOS
 uv sync                              # creates ./.venv and installs deps
-source .venv/bin/activate            # or prefix commands with `uv run`
-everos demo --plain                  # try the local educational demo; no API keys needed
-everos init                          # add one OpenRouter key to ~/.everos/everos.toml
+uv run everos demo --plain           # try the local educational demo; no API keys needed
+uv run everos init                   # add one OpenRouter key to ~/.everos/everos.toml
 
-everos --help
+uv run everos --help
 make test
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,7 +109,11 @@ uv pip install everos
 召回记忆：
 
 ```bash
+# 如果你是通过 package 安装 EverOS：
 everos demo
+
+# 如果你是 fork/clone 这个仓库，且还没有激活 .venv：
+uv run everos demo
 ```
 
 输入一条希望 EverOS 记住的信息，再提出相关问题，即可直观看到记忆经过
@@ -274,11 +278,10 @@ sudo apt-get install -y libreoffice          # Debian / Ubuntu
 git clone https://github.com/EverMind-AI/EverOS.git
 cd EverOS
 uv sync                              # creates ./.venv and installs deps
-source .venv/bin/activate            # or prefix commands with `uv run`
-everos demo --plain                  # 先体验本地 educational demo；不需要 API keys
-everos init                          # 把一个百炼 DashScope Key 配置到 ~/.everos/everos.toml
+uv run everos demo --plain           # 先体验本地 educational demo；不需要 API keys
+uv run everos init                   # 把一个百炼 DashScope Key 配置到 ~/.everos/everos.toml
 
-everos --help
+uv run everos --help
 make test
 ```
 


### PR DESCRIPTION
## Summary
- Clarifies that source checkouts should use uv run everos demo, while installed CLIs can use everos demo.
- Keeps the demo dot-sphere physically round inside responsive terminal frames by projecting with one shared radius.
- Adds depth perspective so the crystal reads as a sphere: front hemisphere projects outward while rear particles recede.
- Preserves the supernova start frame so the celebrating transition begins from the exact recalled sphere.

## Visual checks
- Responsive sphere comparison: /private/tmp/everos-sphere-depth/sphere-depth-responsive-comparison.png
- medium 160x50 subdot ratio: 1.0
- wide 240x70 subdot ratio: 1.0

## Validation
- python3 scripts/check_pr_title.py "fix: render demo sphere with depth perspective"
- python3 scripts/check_docs.py
- git diff --check
- uv run pytest tests/unit/test_entrypoints/test_tui/test_demo_sphere.py tests/unit/test_entrypoints/test_tui/test_demo_app.py
- uv run everos demo --plain
- python3 scripts/check_commit_messages.py origin/main..HEAD